### PR TITLE
docs: add instructions for SSH access to Juju machines

### DIFF
--- a/docs/how_to_ssh_to_juju_machines.md
+++ b/docs/how_to_ssh_to_juju_machines.md
@@ -1,4 +1,4 @@
-# SSH Access to Juju machines
+# How to SSH to Juju machines
 
 The SSH access to charmed MAAS machines can be performed either via Juju CLI or directly from the user system. In both cases, direct network connectivity between the user system and the Juju machines should be guaranteed.
 
@@ -19,14 +19,14 @@ ssh ubuntu@$MACHINE_IP
 ubuntu@10.240.246.5: Permission denied (publickey).
 ```
 
-## Adding keys to the model
+## Add keys to the model
 
 To be able to SSH to the machines, at least one valid SSH key should be added to the Juju model. Juju supports adding SSH keys by providing their public part, or by importing them from a GitHub or Launchpad account.
 
 > [!Note]
-> The SSH keys can be added to the model by using a Juju snap that is authenticated to the Juju controller. Assuming that Juju is bootstrapped with `juju-bootstrap` module, the command to add the key(s) can be executed from the same host that used to apply the module.
+> The SSH keys can be added to the model by using a Juju snap that is authenticated to the Juju controller. Assuming that Juju is bootstrapped with `juju-bootstrap` module, the command to add the key(s) can be executed from the same host that used to apply that module.
 
-### Adding a local SSH key
+### Add a local SSH key
 
 ```bash
 juju add-ssh-key "$(cat ~/.ssh/id_ed25519.pub)"
@@ -35,23 +35,17 @@ Keys used in model: admin/maas
 24:a5:d6:46:97:13:c8:f9:17:58:3c:c8:99:15:71:82 (ubuntu@maas-bastion)
 ```
 
-### Importing a SSH key from GH/LP
+### Import an SSH key from GitHub or Launchpad
 
 ```bash
 # GitHub
 juju import-ssh-key gh:sample-user
-juju ssh-keys
-Keys used in model: admin/maas
-74:96:43:55:b3:3d:bd:bf:f3:74:96:43:55:74:96:43 (sample-user@github/12302123 # ssh-import-id gh:sample-user)
 
 # Launchpad
 juju import-ssh-key lp:sample-user
-juju ssh-keys
-Keys used in model: admin/maas
-74:96:43:55:b3:3d:bd:bf:f3:74:96:43:55:74:96:43 (sample-user # ssh-import-id lp:sample-user)
 ```
 
-## SSH Access
+## Access a machine via SSH
 
 After adding at least one key in the model, then SSH access is granted.
 
@@ -80,7 +74,9 @@ Once added to the model, the SSH keys can be listed and/or removed.
 juju ssh-keys
 Keys used in model: admin/maas
 74:96:43:55:b3:3d:bd:bf:f3:74:96:43:55:74:96:43 (sample-user # ssh-import-id lp:sample-user)
+
 juju remove-ssh-key 74:96:43:55:b3:3d:bd:bf:f3:74:96:43:55:74:96:43
+
 juju ssh-keys
 No keys to display.
 ```


### PR DESCRIPTION
- Add instructions on how to allow `juju ssh` to operate
- Add instructions on how to add or import SSH key(s) to a Juju model
- Add instructions on how to remove a SSH key from a Juju model