### PR TITLE
docs: architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ flowchart TB
   class CTRL bootstrapManaged
   class MODEL deployManaged
 ```
-This diagram describes the system architecture after running the three modules in this repository on a LXD-based cloud. Different `juju-applications` are identified with colored markers (🟡🔵🟠🟣) and optional units are represented with dashed outlines.
+This diagram describes the system architecture of infrastructure deployed by the three terraform modules in this repository, on a LXD-based cloud, for both single and multi-node deploments. Distinct Juju applications are represented with colored markers (🟡🔵🟠🟣) on each unit, and the parts of the architecture that are optional depending on your configuration are represented with dashed outlines.
 
 
 A charmed MAAS deployment consists of the following atomic components:

--- a/docs/how_to_deploy_multi_node.md
+++ b/docs/how_to_deploy_multi_node.md
@@ -9,8 +9,7 @@ Deployment occurs in multiple stages, where first a single-node deployment is co
 > [!NOTE]
 > part of the reason for one unit -> three units is to avoid [this known issue](https://github.com/canonical/maas-charms/issues/315)
 
-<!-- TODO: Add a diagram for multi-node deployment here. -->
-
+Copy the configuration sample, modifying the entries as required.
 ```bash
 cp config/maas-deploy/config.tfvars.sample config/maas-deploy/config.tfvars
 ```

--- a/docs/how_to_deploy_single_node.md
+++ b/docs/how_to_deploy_single_node.md
@@ -6,8 +6,6 @@ It is easier to create a single node cluster with the [MAAS and PostgreSQL snaps
 
 The benefit of following these instructions and configuring a charmed deployment is, however, that following the final steps in [how to deploy multi-node](./how_to_deploy_multi_node.md) deployment allows scaling the cluster with relative ease after initial setup.
 
-<!-- TODO: Add a diagram for single node deployment here. -->
-
 Copy the MAAS deployment configuration sample, modifying the entries as required.
 It is recommended to pay attention to the following configuration options and supply their values as required:
 


### PR DESCRIPTION
Add a single architecture diagram representing single and multi node deployments. Removed old todos.