### PR TITLE
docs: architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@ This repository exists as a deployment and configuration solution for a [Charmed
 
 ## Contents
 
-- [Architecture](#architecture)
-- [Deployment Instructions](#deployment-instructions)
-  - Optional [Juju Bootstrap](./docs/how_to_bootstrap_juju.md)
-  - [Single Node MAAS](./docs/how_to_deploy_single_node.md) or [Multi Node MAAS](./docs/how_to_deploy_multi_node.md)
-  - [Configuration](./docs/how_to_configure_maas.md)
-- [Appendix - Backup and Restore](#appendix---backup-and-restore)
-- [Appendix - Prerequisites](#appendix---prerequisites)
-- [Appendix - Troubleshooting](./docs/troubleshooting.md)
+- [Terraform driven Charmed MAAS deployment](#terraform-driven-charmed-maas-deployment)
+  - [Contents](#contents)
+  - [Architecture](#architecture)
+      - [MAAS Regions](#maas-regions)
+      - [MAAS Agents](#maas-agents)
+      - [PostgreSQL](#postgresql)
+      - [Juju Controller](#juju-controller)
+      - [LXD Cloud](#lxd-cloud)
+  - [Deployment Instructions](#deployment-instructions)
+  - [Appendix - Backup and Restore](#appendix---backup-and-restore)
+  - [Appendix - Prerequisites](#appendix---prerequisites)
 
 The full MAAS cluster deployment consists of: one optional bootstrapping, one of two Deployment, and a recommended (but optional), Terraform modules that should be run in the following order:
 
@@ -28,9 +31,125 @@ The full MAAS cluster deployment consists of: one optional bootstrapping, one of
 
 ## Architecture
 
-A charmed MAAS deployment consists of the following atomic components:
+```mermaid
+flowchart TB
+  %% Styling for different concepts (not much right now!)
+  classDef unitOptional color:#888888,stroke-dasharray: 5 5
+  classDef multiNodeGroup stroke-dasharray: 5 5
 
-<!-- TODO: Fill out with further details, this is a little bare. -->
+  %% Terraform module colors
+  classDef tfBootstrap fill:#4CAF50,stroke:#2E7D32
+  classDef tfDeploy fill:#2196F3,stroke:#1565C0
+  classDef tfConfig fill:#F44336,stroke:#C62828
+
+  %% Group outlines matching module colors
+  classDef bootstrapManaged stroke:#4CAF50,stroke-width:2px
+  classDef deployManaged stroke:#2196F3,stroke-width:2px
+
+  %% LXD Cloud
+  subgraph CLOUD["☁️ LXD-based cloud"]
+    direction TB
+
+    %% Juju Controller
+    subgraph CTRL["Container"]
+      JC["Juju controller"]
+    end
+
+    %% MAAS Model
+    subgraph MODEL["Juju model - &quotmaas&quot"]
+
+      %% MAAS collocated machines
+      subgraph MAAS_MACHINES["MAAS machines"]
+         subgraph MAAS_M0["VM-3"]
+
+          R0["🟣 maas-region/0"]
+          A0["🟠 maas-agent/0"]
+        end
+         subgraph MAAS_MULTINODE["Multi-node deployment"]
+          subgraph MAAS_M1["VM-4"]
+
+            R1["🟣 maas-region/1"]
+            A1["🟠 maas-agent/1"]
+          end
+          subgraph MAAS_M2["VM-5"]
+
+            R2["🟣 maas-region/2"]
+            A2["🟠 maas-agent/2"]
+          end
+         end
+        %% Force horizontal layout
+        MAAS_M0 ~~~ MAAS_M1 ~~~ MAAS_M2
+      end
+
+      %% PostgreSQL dedicated machines
+      subgraph PG_MACHINES["PostgreSQL machines"]
+         subgraph PG_M0["VM-0"]
+           PG0["🔵 postgresql/0"]
+        end
+        subgraph PG_MULTINODE["Multi-node deployment"]
+          subgraph PG_M1["VM-1"]
+            PG1["🔵 postgresql/1"]
+          end
+          subgraph PG_M2["VM-2"]
+            PG2["🔵 postgresql/2"]
+          end
+        end
+        %% Force horizontal layout
+        PG_M0 ~~~ PG_M1 ~~~ PG_M2
+      end
+
+      %% Force vertical group layout
+      MAAS_MACHINES ~~~ PG_MACHINES
+      PG_MACHINES ~~~ BACKUP_M0
+
+      %% Backup machine
+        subgraph BACKUP_M0["Container"]
+        S3_PG["🟡 s3-integrator-postgresql/0"]
+        S3_MAAS["🟡 s3-integrator-maas/0"]
+      end
+    end
+  end
+
+  %% Terraform modules (top level)
+  TF1(["Module: juju-bootstrap"])
+  TF2(["Module: maas-deploy"])
+  TF3(["Module: maas-config"])
+
+  %% External S3 Storage
+  S3_BUCKET_PG[("S3 Bucket<br/>Path: /postgresql")]
+  S3_BUCKET_MAAS[("S3 Bucket<br/>Path: /maas")]
+
+  %% Application integrations
+  R0 ~~~ A0
+  R1 ~~~ A1
+  R2 ~~~ A2
+
+  %% Terraform module relationships
+  TF1 -.->|creates| CTRL
+  TF2 -.->|creates| MODEL
+  TF3 -.->|configures| MAAS_MACHINES
+
+  %% S3 storage connections
+  S3_PG ==> S3_BUCKET_PG
+  S3_MAAS ==>S3_BUCKET_MAAS
+
+  %% Apply styles
+  class A0,A1,A2,S3_PG,S3_MAAS unitOptional
+  class PG_MULTINODE,MAAS_MULTINODE multiNodeGroup
+
+  %% Terraform modules
+  class TF1 tfBootstrap
+  class TF2 tfDeploy
+  class TF3 tfConfig
+
+  %% Module managed groups
+  class CTRL bootstrapManaged
+  class MODEL deployManaged
+```
+This diagram describes the system architecture of infrastructure deployed by the three Terraform modules in this repository, on a LXD-based cloud, for both single and multi-node deployments. Distinct Juju applications are represented with colored markers (🟡🔵🟠🟣) on each unit, and the parts of the architecture that are optional depending on your configuration are represented with dashed outlines.
+
+
+A charmed MAAS deployment consists of the following atomic components:
 
 #### MAAS Regions
 Charmed deployment of the MAAS Snap, [learn more here](https://charmhub.io/maas-region)

--- a/docs/how_to_deploy_multi_node.md
+++ b/docs/how_to_deploy_multi_node.md
@@ -3,14 +3,15 @@
 This topology will install three MAAS Region nodes, and three PostgreSQL nodes.
 Deployment occurs in multiple stages, where first a single-node deployment is configured, then scaled out to the full complement of units.
 
+See the [architecture section](../README.md#architecture) of README.md for an overview that includes a description of multi-node deployments.
+
 > [!NOTE]
 > As deployed in these steps, this is not a true HA deployment. You will need to supply an external HA proxy with your MAAS endpoints, for example, for true HA.
 
 > [!NOTE]
 > part of the reason for one unit -> three units is to avoid [this known issue](https://github.com/canonical/maas-charms/issues/315)
 
-<!-- TODO: Add a diagram for multi-node deployment here. -->
-
+Copy the configuration sample, modifying the entries as required.
 ```bash
 cp config/maas-deploy/config.tfvars.sample config/maas-deploy/config.tfvars
 ```

--- a/docs/how_to_deploy_single_node.md
+++ b/docs/how_to_deploy_single_node.md
@@ -6,7 +6,7 @@ It is easier to create a single node cluster with the [MAAS and PostgreSQL snaps
 
 The benefit of following these instructions and configuring a charmed deployment is, however, that following the final steps in [how to deploy multi-node](./how_to_deploy_multi_node.md) deployment allows scaling the cluster with relative ease after initial setup.
 
-<!-- TODO: Add a diagram for single node deployment here. -->
+See the [architecture section](../README.md#architecture) of README.md for an overview that includes a description of single-node deployments.
 
 Copy the MAAS deployment configuration sample, modifying the entries as required.
 It is recommended to pay attention to the following configuration options and supply their values as required:


### PR DESCRIPTION
Recreates https://github.com/canonical/maas-terraform-modules/pull/17 .

Add a single architecture diagram representing single and multi node deployments. Removed old todos.