### PR TITLE
fix: change wait for maas model reference breaking maas-deploy

### DIFF
--- a/modules/maas-deploy/main.tf
+++ b/modules/maas-deploy/main.tf
@@ -77,7 +77,7 @@ resource "juju_integration" "maas_region_postgresql" {
 resource "terraform_data" "juju_wait_for_maas" {
   input = {
     model = (
-      juju_integration.maas_region[0].model
+      juju_integration.maas_region_postgresql.model
     )
   }
 


### PR DESCRIPTION
I believe this was a relic left over from https://github.com/canonical/maas-terraform-modules/pull/21