### PR TITLE
fix: Change field of node_script from 'file' to 'script'

### DIFF
--- a/modules/maas-config/main.tf
+++ b/modules/maas-config/main.tf
@@ -129,5 +129,5 @@ resource "maas_dns_record" "test_txt" {
 resource "maas_node_script" "node_scripts" {
   for_each = var.node_scripts
 
-  file = base64encode(file("${var.node_scripts_location}/${each.value}"))
+  script = base64encode(file("${var.node_scripts_location}/${each.value}"))
 }


### PR DESCRIPTION
Renamed required field `file` to `script` in maas-config module to make it align with the MAAS Terraform provider.

This resolves not being able to perform `terraform plan/apply`. It didn't look like there were any bits of documentation of testing in this repo that needed this tweak applying too, but if I missed something please do let me know!