### PR TITLE
chore: update outdated content

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This repository exists as a deployment and configuration solution for a [Charmed
 - [Terraform driven Charmed MAAS deployment](#terraform-driven-charmed-maas-deployment)
   - [Contents](#contents)
   - [Architecture](#architecture)
-      - [MAAS Regions](#maas-regions)
-      - [PostgreSQL](#postgresql)
-      - [Juju Controller](#juju-controller)
-      - [LXD Cloud](#lxd-cloud)
+    - [MAAS Regions](#maas-regions)
+    - [PostgreSQL](#postgresql)
+    - [Juju Controller](#juju-controller)
+    - [LXD Cloud](#lxd-cloud)
   - [Deployment Instructions](#deployment-instructions)
   - [Appendix - Backup and Restore](#appendix---backup-and-restore)
   - [Appendix - Prerequisites](#appendix---prerequisites)
@@ -26,7 +26,6 @@ The full MAAS cluster deployment consists of: one optional bootstrapping, one of
 - [Juju Bootstrap](./modules/juju-bootstrap) - Bootstraps Juju on a provided LXD server or cluster; Optional if you already have an external Juju controller.
 - [MAAS Deploy](./modules/maas-deploy) - Deploys charmed MAAS at a Juju model of the provided Juju controller (`juju-bootstrap` or external)
 - [MAAS Config](./modules/maas-config) - Configures the charmed MAAS deployed by `maas-deploy`; Optional but highly recommended. You *can* configure your MAAS independently, but automation is the recommended pathway.
-
 
 ## Architecture
 
@@ -142,28 +141,31 @@ flowchart TB
   class CTRL bootstrapManaged
   class MODEL deployManaged
 ```
-This diagram describes the system architecture of infrastructure deployed by the three Terraform modules in this repository, on a LXD-based cloud, for both single and multi-node deployments. Distinct Juju applications are represented with colored markers (🟡🔵🟣) on each unit, and the parts of the architecture that are optional depending on your configuration are represented with dashed outlines.
 
+This diagram describes the system architecture of infrastructure deployed by the three Terraform modules in this repository, on a LXD-based cloud, for both single and multi-node deployments. Distinct Juju applications are represented with colored markers (🟡🔵🟣) on each unit, and the parts of the architecture that are optional depending on your configuration are represented with dashed outlines.
 
 A charmed MAAS deployment consists of the following atomic components:
 
 #### MAAS Regions
+
 Charmed deployment of the MAAS Snap, [learn more here](https://charmhub.io/maas-region)
 
 [!Note]: If running in Region only mode (rather than Region+Rack) the installation and configuration of the MAAS Agent is left as an exercise to the user.
 
 #### PostgreSQL
+
 Charmed deployment that connects to MAAS Regions to provide the MAAS Database, [learn more here](https://canonical-charmed-postgresql.readthedocs-hosted.com/16/)
 
 #### Juju Controller
+
 Orchestrates the lifecycle of the deployed charmed applications, [learn more here](https://documentation.ubuntu.com/juju/3.6/reference/controller/)
 
 #### LXD Cloud
+
 Provides the underlying virtual-machine infrastructure that Juju runs on.
-While the development of this repository occured on LXD clouds, Juju does support others too: [learn more here](https://documentation.ubuntu.com/juju/3.6/reference/cloud/)
+While the development of this repository occurred on LXD clouds, Juju does support others too: [learn more here](https://documentation.ubuntu.com/juju/3.6/reference/cloud/)
 
 LXD Containers and Virtual machines are deployed as Juju machines, which Juju uses to deploy charms in.
-
 
 ## Deployment Instructions
 
@@ -175,13 +177,11 @@ These instructions will take you from a bare system to a running MAAS cluster wi
 2. Deploy a [multi-node](./docs/how_to_deploy_multi_node.md) or [single-node](./docs/how_to_deploy_single_node.md) MAAS cluster
 3. [Configure](./docs/how_to_configure_maas.md) your running MAAS instance
 
-
 ## Appendix - Backup and Restore
 
-There exist two suplementary documents for instructions on [How to Backup](./docs/how_to_backup.md) and [How to Restore](./docs/how_to_restore.md) your MAAS Cluster.
+There exist two supplementary documents for instructions on [How to Backup](./docs/how_to_backup.md) and [How to Restore](./docs/how_to_restore.md) your MAAS Cluster.
 
 It is recommended to take a backup of your cluster after initial setup.
-
 
 ## Appendix - Prerequisites
 

--- a/config/maas-deploy/config.tfvars.sample
+++ b/config/maas-deploy/config.tfvars.sample
@@ -50,8 +50,8 @@ charm_maas_region_channel = "latest/edge"
 charm_maas_region_revision = null
 # Operator configuration for MAAS Region Controller deployment
 charm_maas_region_config = {
-    # Deploy region in Region+Rack mode
-    enable_rack_mode = false
+  # Deploy region in Region+Rack mode
+  enable_rack_mode = false
 }
 
 ###

--- a/docs/how_to_backup.md
+++ b/docs/how_to_backup.md
@@ -5,6 +5,7 @@ This document describes how to backup charmed MAAS to an S3 compatible storage b
 This guide includes the backup instructions for both the PostgreSQL database, which stores the majority of the MAAS state, and also additional files stored on disk in the regions. Running backups for both these two applications are required to backup charmed MAAS.
 
 ### Prerequisites
+
 - You need an S3-compatible storage solution with credentials.
 - The `maas-deploy` module must be run with backup enabled as the final stage of the staged deployment detailed in [README.md](../README.md). To achieve this, in your config.tfvars file, set `enable_backup=true`,  provide your S3 parameters, before re-running the terraform apply step. In both multi-node and single-node deployments, this will deploy two `s3-integrator` units, one integrated with `maas-region` and the other with `postgresql`.
 - You should have basic knowledge about Juju and charms, including:
@@ -16,26 +17,34 @@ This guide includes the backup instructions for both the PostgreSQL database, wh
 > This backup and restore functionality is in an early release phase. We recommend testing these workflows in a non-production environment first to verify they meet your specific requirements before implementing in production.
 
 ## Create backup
+
 Creating a backup of charmed MAAS requires two separate backups: the backup of maas-region cluster, and the backup of the PostgreSQL database.
 
 The entities outside the database that are backed up are:
+
 - MAAS OS Images, on the leader region unit.
 - [Curtin preseeds](https://canonical.com/maas/docs/about-machine-customization#p-17465-pre-seeding), on the leader region unit.
 - Region controller system ids.
 
 ### Backup PostgreSQL
+
 1. Note the PostgreSQL secrets required to access the database after a restore:
    1. Show the relevant secret id to reveal by running:
+
        ```bash
        juju secrets --owner=application-postgresql --format json | jq -r 'map_values(select(.label == "database-peers.postgresql.app"))|keys[]'
        ```
+
        ```output
        d2on5mo6jk5c44b94o2g  # example secret id
        ```
+
    1. Reveal the secret and locate the fields `monitoring-password`, `operator-password`, `replication-password`, and `rewind-password`. Copy these and store them in a secure location for the restore:
+
        ```bash
        juju show-secret <id> --reveal
        ```
+
        ```output
        d2on5mo6jk5c44b94o2g:
          revision: 1
@@ -54,7 +63,9 @@ The entities outside the database that are backed up are:
            replication-password: <password-to-copy>
            rewind-password: <password-to-copy>
        ```
+
 1. Create a full backup of `postgresql`. When PostgreSQL TLS is enabled, run this on a replica unit (non-primary), but when PostgreSQL TLS is not enabled this can only be run on the primary (see the [docs](https://canonical-charmed-postgresql.readthedocs-hosted.com/16/how-to/back-up-and-restore/create-a-backup/#create-a-backup)):
+
     ```bash
     juju run postgresql/1 create-backup --wait 5m
     ```
@@ -63,21 +74,25 @@ The entities outside the database that are backed up are:
    > This creates a full PostgreSQL backup. Differential and incremental types are not supported for restoring charmed MAAS.
 
 ### Backup MAAS
-Backup up relevant files on MAAS region controllers outside of the database.
 
+Backup up relevant files on MAAS region controllers outside of the database.
 
 1. (Recommended) Ensure all uploaded custom OS images have finished syncing across regions.
 1. Run the following to create a backup:
+
 ```bash
 juju run maas-region/leader create-backup --wait 5m
 ```
+
 > [!Note]
 > With a large number of OS images, you may have to increase the wait time to avoid Juju timing out waiting for the action to complete.
 
 ## List backups
+
 List existing MAAS backups present in S3. Your MAAS backups and PostgreSQL backups are stored and listed independently.
 
 To view existing backups for `maas-regions` in the specified S3 location:
+
 ```bash
 juju run maas-region/leader list-backups
 ```
@@ -95,14 +110,14 @@ backups: |-
   ------------------------------------------------------------------------------------------------------------
   2025-09-01T14:13:31Z | full backup | finished | 3.6.1    | 1.8GiB     | 7rtx4b, 7wstba, be7mkk | /maas/backup/2025-09-01T14:13:31Z
   2025-09-01T16:37:46Z | full backup | finished | 3.6.1    | 766.7MiB   | 7rtx4b, 7wstba, be7mkk | /maas/backup/2025-09-01T16:37:46Z
-
-
 ```
 
 To view existing backups for PostgreSQL in the PostgreSQL S3 bucket:
-```
+
+```bash
 juju run postgresql/leader list-backups
 ```
+
 ```output
 backups: |-
   Storage bucket name: my-postgresql-bucket
@@ -111,8 +126,8 @@ backups: |-
   backup-id            | action              | status   | reference-backup-id  | LSN start/stop          | start-time           | finish-time          | timeline | backup-path
   -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   2025-08-14T10:33:36Z | full backup         | finished | None                 | 0/8000028 / 0/8011558   | 2025-08-14T10:33:36Z | 2025-08-14T10:33:38Z | 1        | /maas.postgresql/20250814-103336F
-
 ```
 
 ### Resources
+
 - [Charmed PostgreSQL documentation version 16](https://canonical-charmed-postgresql.readthedocs-hosted.com/16/)

--- a/docs/how_to_bootstrap_juju.md
+++ b/docs/how_to_bootstrap_juju.md
@@ -4,8 +4,8 @@ All MAAS cluster deployments requires a running Juju controller. If you are usin
 
 Otherwise, we can use the `juju-bootstrap` Terraform module to get started:
 
-
 Create a trust token for your LXD server/cluster
+
 ```bash
 lxc config trust add --name maas-charms
 ```
@@ -29,6 +29,7 @@ Copy the sample configuration file, modifying the entries as required:
 ```bash
 cp config/juju-bootstrap/config.tfvars.sample config/juju-bootstrap/config.tfvars
 ```
+
 > [!NOTE]
 > At bare minimum you will need to supply the `lxd_trust_token` and `lxd_address` as configured in the `bootstrap-juju` steps, or your externally provided cloud.
 
@@ -57,8 +58,8 @@ Finally, record the `juju_cloud` value from the Terraform output, this will be n
 terraform output -raw juju_cloud
 ```
 
-
 Next steps:
+
 - Deploy a [Single-node](./how_to_deploy_single_node.md) or [Multi-node](./how_to_deploy_multi_node.md) MAAS cluster atop your Juju controller.
 - Configure your running [MAAS](./how_to_configure_maas.md) to finalise your cluster.
 - Setup [Backup](./how_to_backup.md) for MAAS and PostgreSQL.

--- a/docs/how_to_configure_maas.md
+++ b/docs/how_to_configure_maas.md
@@ -5,6 +5,7 @@ Copy the `maas-config` configuration sample, and modify as necessary. It is requ
 ```bash
 cp config/maas-config/config.tfvars.sample config/maas-config/config.tfvars
 ```
+
 ```bash
 # The MAAS URL as returned from the `maas-deploy` plan.
 maas_url = "..."
@@ -13,7 +14,9 @@ maas_key = "..."
 
 # Additionally modify other variables if desired
 ```
+
 > [!NOTE] If deploying in Region+Rack mode, you can additionally serve DHCP from a rack controller with the following configuration values
+>
 > ```bash
 > # The hostname of a machine from `maas_machines` to use as a rack controller.
 > rack_controller = "..."
@@ -42,7 +45,6 @@ Apply the Terraform plan if the above sanity check passed
 terraform apply -var-file ../../config/maas-config/config.tfvars -auto-approve
 ```
 
-
 # MAAS Access
 
 All modules have been applied at this point, and a running MAAS instance should be available, with the following known values:
@@ -51,13 +53,13 @@ All modules have been applied at this point, and a running MAAS instance should 
 - MAAS Admin API Key
 - MAAS Admin Login Credentials
 
-
 You should now access the charmed MAAS UI [from your browser](https://canonical.com/maas/docs/how-to-get-maas-up-and-running#p-9034-web-ui-setup), or configure the [MAAS CLI](https://canonical.com/maas/docs/how-to-get-maas-up-and-running#p-9034-cli-setup) to access the running Instance. Happy MAAS-ing!
 
-
 Previous steps:
+
 - [Bootstrap](./how_to_bootstrap_juju.md) a new Juju controller, or use an [Externally](./how_to_deploy_to_a_bootstrapped_controller.md) supplied one instead.
 - Deploy a [Single-node](./how_to_deploy_single_node.md) or [Multi-node](./how_to_deploy_multi_node.md) MAAS cluster atop your Juju controller.
 
 Next steps:
+
 - Setup [Backup](./how_to_backup.md) for MAAS and PostgreSQL.

--- a/docs/how_to_deploy_multi_node.md
+++ b/docs/how_to_deploy_multi_node.md
@@ -12,6 +12,7 @@ See the [architecture section](../README.md#architecture) of README.md for an ov
 > part of the reason for one unit -> three units is to avoid [this known issue](https://github.com/canonical/maas-charms/issues/315)
 
 Copy the configuration sample, modifying the entries as required.
+
 ```bash
 cp config/maas-deploy/config.tfvars.sample config/maas-deploy/config.tfvars
 ```
@@ -20,6 +21,7 @@ You should initially ensure the configuration contains `enable_maas_ha=false` an
 
 > [!NOTE]
 > You *MUST* increase the PostgreSQL connections for a multi-node deployment to something larger, for example:
+>
 > ```bash
 > charm_postgresql_config = {
 >   experimental_max_connections = 300
@@ -31,6 +33,7 @@ You should initially ensure the configuration contains `enable_maas_ha=false` an
 
 > [!NOTE]
 > To deploy in Region+Rack mode, you will need to provide the following change to the MAAS region config:
+>
 > ```bash
 > charm_maas_region_config {
 >     enable_rack_mode = true
@@ -103,10 +106,11 @@ Machine  State    Address                                 Inst id        Base   
 5        started  10.120.100.23                           juju-43f429-5  ubuntu@22.04      Running
 ```
 
-
 Previous steps:
+
 - [Bootstrap](./how_to_bootstrap_juju.md) a new Juju controller, or use an [Externally](./how_to_deploy_to_a_bootstrapped_controller.md) supplied one instead.
 
 Next steps:
+
 - Configure your running [MAAS](./how_to_configure_maas.md) to finalise your cluster.
 - Setup [Backup](./how_to_backup.md) for MAAS and PostgreSQL.

--- a/docs/how_to_deploy_single_node.md
+++ b/docs/how_to_deploy_single_node.md
@@ -17,6 +17,7 @@ cp config/maas-deploy/config.tfvars.sample config/maas-deploy/config.tfvars
 
 > [!NOTE]
 > To deploy in Region+Rack mode, you will need to provide the following change to the MAAS region config:
+>
 > ```bash
 > charm_maas_region_config {
 >     enable_rack_mode = true
@@ -75,10 +76,11 @@ Machine  State    Address                                 Inst id        Base   
 1        started  fd42:3eef:9375:6168:216:3eff:fe0a:a497  juju-43f429-1  ubuntu@24.04      Running
 ```
 
-
 Previous steps:
+
 - [Bootstrap](./how_to_bootstrap_juju.md) a new Juju controller, or use an [Externally](./how_to_deploy_to_a_bootstrapped_controller.md) supplied one instead.
 
 Next steps:
+
 - Configure your running [MAAS](./how_to_configure_maas.md) to finalise your cluster.
 - Setup [Backup](./how_to_backup.md) for MAAS and PostgreSQL.

--- a/docs/how_to_deploy_to_a_bootstrapped_controller.md
+++ b/docs/how_to_deploy_to_a_bootstrapped_controller.md
@@ -43,8 +43,8 @@ In this case, the Juju controller credentials must be provided by the user as en
     terraform plan -var-file ../../config/maas-deploy/config.tfvars
     ```
 
-
 Next steps:
+
 - Deploy a [Single-node](./how_to_deploy_single_node.md) or [Multi-node](./how_to_deploy_multi_node.md) MAAS cluster atop your Juju controller.
-- Configure your running [MAAS](./how_to_configure_maas.md) to finalise your cluster.
+- Configure your running [MAAS](./how_to_configure_maas.md) to finalize your cluster.
 - Setup [Backup](./how_to_backup.md) for MAAS and PostgreSQL.

--- a/docs/how_to_restore.md
+++ b/docs/how_to_restore.md
@@ -1,15 +1,19 @@
 # How to restore charmed MAAS
+
 This is a guide on how to restore from an existing charmed MAAS backup as detailed in [how_to_backup.md](how_to_backup.md).
 
 > [!Note]
 > This backup and restore functionality is in an early release phase. We recommend testing these workflows in a non-production environment first to verify they meet your specific requirements before implementing in production.
->
+
 ### Before you begin
+
 It's important to understand the following:
+
 - The restore process outlined in this document is for a fresh install of MAAS and PostgreSQL.
 - When restoring, deploy the same MAAS and PostgreSQL channel versions that were used to create the backup. You can see the version of the maas-region charm used for a particular backup in `mybucket/mypath/backup/<backup-id>/backup_metadata.json`, and the version of PostgreSQL used in `mybucket/mypath/backup/<stanza-name>/backup.info`.
 
 ### Prerequisites
+
 This restoration guide assumes the following:
 
 - The backup steps outlined in [how_to_backup.md](how_to_backup.md) were followed for both `maas-region` and `postgresql`.
@@ -17,20 +21,26 @@ This restoration guide assumes the following:
 - You have identified the backups IDs for `maas-region` and `postgresql`, using the `list-backups` commands if needed.
 
 ## Restore from backup
+
 The restore process requires deploying a fresh MAAS environment that matches your backup configuration, then restoring PostgreSQL and each region separately.
 
 ### Step 1: Determine your target configuration
+
 Check your MAAS backup for controller count:
+
 ```bash
 juju run maas-region/leader list-backups
 ```
+
 The number of controller IDs in your target backup determines if you deploy MAAS in a single-node or a multi-node topology:
+
 - 1 controller ID -> single-node setup (`enable_maas_ha=false`)
 - 3 controller IDs -> multi-node setup (`enable_maas_ha=true`)
 
 The restore is always performed with PostgreSQL deployed as a single-node (`enable_postgres_ha=false`), and scaled up to multi-node after the restore process if desired.
 
 ### Step 2: Staged deployment of a fresh environment
+
 Deploy the `maas-deploy` as outlined in [README.md](../README.md) to your target configuration, ensuring both `enable_backup=false` and `enable_postgres_ha=false` regardless of your configuration.
 
 When you've deployed your target configuration, re-run your `terraform apply` with `enable_backup=true` to deploy the necessary backup configuration.
@@ -38,28 +48,41 @@ When you've deployed your target configuration, re-run your `terraform apply` wi
 After the final stage, Terraform should complete and your PostgreSQL unit should be in a blocked state with the message "the s3 repository has backups from another cluster". This is expected and you can proceed with the restore process.
 
 ### Step 3: Perform the restore
+
 Restore your backup data:
+
 1. Remove the `maas-region`-`postgresql` relation:
+
    ```bash
    juju remove-relation maas-region postgresql
    ```
+
 1. Create a secret with password values you obtained and securely stored in the backup step:
+
    ```bash
    juju add-secret mypostgresqlsecret monitoring=<password1> operator=<password2> replication=<password3> rewind=<password4>
    ```
+
 1. Grant the secret to the `postgresql` application:
+
    ```bash
    juju grant-secret mypostgresqlsecret postgresql
    ```
+
 1. Restore PostgreSQL with the relevant backup id. Wait for this to complete:
+
    ```bash
    juju run postgresql/leader restore backup-id=yyyy-mm-ddThh:mm:ssZ
    ```
+
 1. To restore each region, the following command needs to be executed on each region with a different controller-id for each, obtained from the maas-region `list-backups` action:
+
    ```bash
    juju run maas-region/${i} restore-backup backup-id=yyyy-mm-ddThh:mm:ssZ controller-id=${id} --wait 10m
    ```
+
    For example:
+
    ```bash
    juju run maas-region/0 restore-backup backup-id=yyyy-mm-ddThh:mm:ssZ controller-id=8ppr6w --wait 10m
    juju run maas-region/1 restore-backup backup-id=yyyy-mm-ddThh:mm:ssZ controller-id=0eq9qa --wait 10m
@@ -67,18 +90,24 @@ Restore your backup data:
    ```
 
 ### Step 4: Complete the deployment
+
 1. You cannot backup the new database to the same location as your previous cluster by design. Change your `s3-integrator-postgresql` path or bucket to store future backups of PostgreSQL using the path below:
+
    ```bash
    juju config s3-integrator-postgresql path=postgresql-restore-1
    ```
+
 1. Update the relevant variable in your `config.tfvars` to the path set in the previous step.
 1. Integrate `postgresql` and `maas-region`:
+
    ```bash
    juju integrate postgresql maas-region
    ```
+
 1. If you would like to run PostgreSQL as a multi-node deployment (a total of 3 PostgreSQL units), now you can re-run your `terraform apply` step for the `maas-deploy` module as detailed in [README.md](../README.md) with `enable_postgres_ha=true`, and wait for its completion.
 
    Otherwise, simply re-run the `terraform apply` step for the `maas-deploy` module to ensure your configuration is now managed by Terraform. You should only observe a plan with modifications to the output:
+
    ```bash
    ❯ terraform apply -var-file ../../config/maas-setup/config.tfvars
    juju_model.maas_model: Refreshing state... [id=cada3a8b-9e2d-482f-81d7-9381bbc5e3ae]
@@ -99,48 +128,65 @@ Restore your backup data:
 You should now have a restored MAAS deployment, managed by Terraform.
 
 ### Step 5: Verify restore
+
 1. Once MAAS has finished re-initialization, get the new endpoint using:
+
    ```bash
    juju run maas-region/leader get-api-endpoint
    ```
+
 1. Verify your restore has been successful by opening the UI, logging in, and check your restored data, including machines, controllers, and OS images, are visible.
 
-
 ## Troubleshooting
+
 #### Cancel an action
+
 After running a juju run command, one of the first lines of output will be:
+
 ```output
 Waiting for task 64...
 ```
+
 `ctrl` + `c` will not stop the running juju action. Use the number as the task id to cancel a running action:
-```
+
+```bash
 juju cancel-task <task-id>
 ```
 
 #### Stuck initializing maas database/ unable to delete custom image upon restore
+
 When restoring, you may run into MAAS being stuck initializing. If you are restoring MAAS in a single-node topology, you will not be able to access MAAS, or with MAAS in a multi-node topology you might be able to access some regions that are not stuck initializing.
 
 This is due to custom images not being fully backed up on regions, but they were backed up in the database, due to images not being synced across all regions at the time of backup. To resolve this difference, you need to remove the problematic custom image entry from the database before forcing MAAS to re-initialize, as outlined below.
 
 1. Obtain the operator password of the database as outlined in the backup steps.
 1. SSH into the `postgresql` node:
+
    ```bash
    juju ssh postgresql/leader
    ```
+
 1. Find the database IPv4 address of the database from the output of:
+
    ```bash
    ip a
    ```
+
 1. Access the PostgreSQL terminal by running the following, ensuring to specify the IP address of the PostgreSQL:
+
    ```bash
    sudo psql -U operator -h 10.237.137.164 -d maas_region_db
    ```
+
 1. Enter the operator password you obtained from step 1. Note this is may not be the same as the operator password used to restore.
 1. Identify the problematic custom image database id(s). If you have no access to any working regions, this will require to you look back at recently uploaded images in the `maasserver_bootresource` table:
+
    ```bash
    SELECT * FROM maasserver_bootresource ORDER BY updated DESC;
    ```
+
 1. Run the following statement for each problematic image, replacing the `BAD_RESOURCE_ID` with the image id:
+
    ```sql
    BEGIN;
 
@@ -167,9 +213,12 @@ This is due to custom images not being fully backed up on regions, but they were
 
    COMMIT;
    ```
+
 1. On your Juju client, re-integrate `maas-region` and `postgresql` to re-initialize `maas-region`:
+
    ```bash
    juju remove-relation maas-region postgresql
    juju integrate maas-region postgresql
    ```
+
 You should now be able to access MAAS. Re-upload the custom image, if required.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,7 +15,6 @@ To increase the connections, simply modify the PostgreSQL `experimental_max_conn
 
 To fetch the actual minimum connections required, refer to [this article](https://canonical.com/maas/docs/installation-requirements#p-12448-postgresql) on the MAAS docs.
 
-
 ## Out-Of-Memory
 
 To run a Multi-Node MAAS and/or PostgreSQL on a single machine, the default memory constraints require your host to have at least 32GB RAM. If you wish to reduce this, adjust the VM constraints variables in your `maas-deploy/config.tfvars` file:
@@ -24,8 +23,8 @@ To run a Multi-Node MAAS and/or PostgreSQL on a single machine, the default memo
 maas_constraints     = "cores=1 mem=2G virt-type=virtual-machine"
 postgres_constraints = "cores=1 mem=2G virt-type=virtual-machine"
 ```
-This would limit VMs to 1 core and 2GB of RAM. It is recommended to modify and test these values to suit your exact setup, ensuring adequate resources are still provided to meet minimum required overhead.
 
+This would limit VMs to 1 core and 2GB of RAM. It is recommended to modify and test these values to suit your exact setup, ensuring adequate resources are still provided to meet minimum required overhead.
 
 ## Troubleshooting HA mode
 

--- a/modules/maas-deploy/variables.tf
+++ b/modules/maas-deploy/variables.tf
@@ -59,7 +59,7 @@ variable "lxd_project" {
 variable "charm_postgresql_channel" {
   description = "Operator channel for PostgreSQL deployment"
   type        = string
-  default     = "16/candidate"
+  default     = "16/stable"
 }
 
 variable "charm_postgresql_revision" {
@@ -72,20 +72,6 @@ variable "charm_postgresql_config" {
   description = "Operator configuration for PostgreSQL deployment"
   type        = map(string)
   default     = {}
-}
-
-variable "max_connections" {
-  description = "Maximum number of concurrent connections to allow to the database server"
-  type        = string
-  default     = "default"
-}
-
-variable "max_connections_per_region" {
-  description = <<EOF
-    Maximum number of concurrent connections to allow to the database server per region
-  EOF
-  type        = number
-  default     = 50
 }
 
 ###


### PR DESCRIPTION
- Improve Markdown syntax
- Fix typos, including switch to US English
- Format config samples
- Remove unused Terraform variables
- Set default channel of PostgreSQL to `16/stable`