### PR TITLE
chore: Point maas-deploy to the maas-region 3.7/edge charm channel

### DIFF
--- a/modules/maas-deploy/variables.tf
+++ b/modules/maas-deploy/variables.tf
@@ -81,7 +81,7 @@ variable "charm_postgresql_config" {
 variable "charm_maas_region_channel" {
   description = "Operator channel for MAAS Region Controller deployment"
   type        = string
-  default     = "3.6/edge"
+  default     = "3.7/edge"
 }
 
 variable "charm_maas_region_revision" {


### PR DESCRIPTION
This change modifies the maas-deploy module to point to the 3.7/edge charm channel, that the charm is updated to track MAAS 3.7.