### PR TITLE
Add model_defaults support to juju-bootstrap module

### DIFF
--- a/config/juju-bootstrap/config.tfvars.sample
+++ b/config/juju-bootstrap/config.tfvars.sample
@@ -7,3 +7,16 @@ cloud_name = "anvil-training"
 lxd_project = "anvil-training"
 # The LXD trust token that Juju should use to authenticate to LXD
 lxd_trust_token = "1234lkjh..."
+
+# Model defaults configuration (optional)
+# Uncomment and configure to pass model configuration defaults to juju bootstrap
+# model_defaults = {
+#   http-proxy       = "http://squid:3128"
+#   https-proxy      = "http://squid:3128"
+#   no-proxy         = "localhost,127.0.0.1"
+#   apt-http-proxy   = "http://squid:3128"
+#   apt-https-proxy  = "http://squid:3128"
+#   snap-http-proxy  = "http://squid:3128"
+#   snap-https-proxy = "http://squid:3128"
+# }
+

--- a/modules/juju-bootstrap/main.tf
+++ b/modules/juju-bootstrap/main.tf
@@ -1,7 +1,8 @@
 resource "terraform_data" "bootstrap_juju" {
   input = {
-    cloud_name  = var.cloud_name
-    lxd_project = var.lxd_project
+    cloud_name     = var.cloud_name
+    lxd_project    = var.lxd_project
+    model_defaults = var.model_defaults
   }
 
   provisioner "local-exec" {
@@ -18,7 +19,7 @@ resource "terraform_data" "bootstrap_juju" {
 
       juju add-cloud --client ${self.input.cloud_name} -f clouds.yaml
       juju add-credential ${self.input.cloud_name} -f credentials.yaml --client
-      juju bootstrap ${self.input.cloud_name} --config project=${self.input.lxd_project}
+      juju bootstrap ${self.input.cloud_name} --config project=${self.input.lxd_project} ${local.model_defaults_args}
     EOT
   }
 
@@ -40,4 +41,8 @@ locals {
     lxd_trust_token = var.lxd_trust_token,
     cloud_name      = var.cloud_name,
   })
+  
+  model_defaults_args = join(" ", [
+    for key, value in var.model_defaults : "--model-default ${key}=${value}"
+  ])
 }

--- a/modules/juju-bootstrap/variables.tf
+++ b/modules/juju-bootstrap/variables.tf
@@ -19,3 +19,9 @@ variable "lxd_trust_token" {
   description = "The LXD trust token that Juju should use to authenticate to LXD"
   type        = string
 }
+
+variable "model_defaults" {
+  description = "Map of model configuration defaults to pass to juju bootstrap (e.g., http-proxy, https-proxy, no-proxy, apt-http-proxy, etc.)"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Introduce a flexible model_defaults variable to pass configuration defaults to the juju bootstrap command using a map-based approach.

Changes:
- Add model_defaults map variable that accepts any key-value pairs
- Update bootstrap command to dynamically build --model-default arguments from the map using a for loop
- Update sample config with model_defaults map example including common proxy configuration options

This approach allows users to specify any Juju model configuration defaults.

Fixes: https://github.com/canonical/maas-terraform-modules/issues/33