### PR TITLE
Add model_config support to maas-deploy module

### DIFF
--- a/config/maas-deploy/config.tfvars.sample
+++ b/config/maas-deploy/config.tfvars.sample
@@ -14,6 +14,13 @@ enable_postgres_ha = false
 enable_maas_ha = false
 # The LXD project in which to create the VMs for Juju
 lxd_project = "default"
+# Map of additional model configuration parameters
+# Uncomment and configure to pass model configuration to the MAAS Juju model
+# model_config = {
+#   juju-http-proxy       = "http://10.21.2.1:3128"
+#   juju-https-proxy      = "http://10.21.2.1:3128"
+#   juju-no-proxy         = "10.0.0.1/24,10.21.2.0/24,localhost,127.0.0.1"
+# }
 # Use the following constraints for the machines
 # Increase cores and mem for larger MAAS installations
 # We recommend using virtual machines. If you are curious

--- a/modules/maas-deploy/main.tf
+++ b/modules/maas-deploy/main.tf
@@ -6,9 +6,12 @@ resource "juju_model" "maas_model" {
     region = var.juju_cloud_region
   }
 
-  config = {
-    project = var.lxd_project
-  }
+  config = merge(
+    var.model_config,
+    {
+      project = var.lxd_project
+    }
+  )
 }
 
 resource "juju_machine" "postgres_machines" {

--- a/modules/maas-deploy/variables.tf
+++ b/modules/maas-deploy/variables.tf
@@ -53,6 +53,12 @@ variable "lxd_project" {
   default     = "default"
 }
 
+variable "model_config" {
+  description = "Map of additional model configuration parameters (e.g., http-proxy, https-proxy, no-proxy, etc.)"
+  type        = map(string)
+  default     = {}
+}
+
 ###
 ## PostgreSQL configuration
 ###


### PR DESCRIPTION
Introduce a flexible model_config variable to pass additional configuration parameters to the MAAS Juju model.

Changes:
- Add model_config map variable that accepts any key-value pairs
- Update juju_model resource to merge model_config with project config
- Update sample config with model_config example for proxy settings

This allows users to specify additional Juju model configuration such as proxy settings without modifying the module code.