### PR TITLE
feat: added juju_ssh_key resource to maas_deploy module

### DIFF
--- a/config/maas-deploy/config.tfvars.sample
+++ b/config/maas-deploy/config.tfvars.sample
@@ -21,6 +21,8 @@ lxd_project = "default"
 #   juju-https-proxy      = "http://10.21.2.1:3128"
 #   juju-no-proxy         = "10.0.0.1/24,10.21.2.0/24,localhost,127.0.0.1"
 # }
+# Path to the SSH key to add to the MAAS Juju model
+# path_to_ssh_key = "/home/ubuntu/.ssh/id_ed25519.pub"
 # Use the following constraints for the machines
 # Increase cores and mem for larger MAAS installations
 # We recommend using virtual machines. If you are curious

--- a/modules/maas-deploy/main.tf
+++ b/modules/maas-deploy/main.tf
@@ -14,6 +14,12 @@ resource "juju_model" "maas_model" {
   )
 }
 
+resource "juju_ssh_key" "model_ssh_key" {
+  count      = var.path_to_ssh_key != null ? 1 : 0
+  model_uuid = juju_model.maas_model.uuid
+  payload    = trimspace(file(var.path_to_ssh_key))
+}
+
 resource "juju_machine" "postgres_machines" {
   count       = var.enable_postgres_ha ? 3 : 1
   model_uuid  = juju_model.maas_model.uuid

--- a/modules/maas-deploy/variables.tf
+++ b/modules/maas-deploy/variables.tf
@@ -59,6 +59,12 @@ variable "model_config" {
   default     = {}
 }
 
+variable "path_to_ssh_key" {
+  description = "Path to the SSH key to add to the MAAS Juju model"
+  type        = string
+  default     = null
+}
+
 ###
 ## PostgreSQL configuration
 ###


### PR DESCRIPTION
Introduce the juju_ssh_key resource in order to automatically add an ssh key to the MAAS Juju model.

Changes:

- Add `path_to_ssh_key` string variable that accepts a path to an ssh public key
- Update `main.tf` in the maas_deploy module to add the `juju_ssh_key` resource. This is a conditional resource based on the presence of the `path_to_ssh_key` variable.
- Update sample config with `path_to_ssh_key` example