### PR TITLE
fix: add new haproxy non-tls relations

### DIFF
--- a/modules/maas-deploy/api.tf
+++ b/modules/maas-deploy/api.tf
@@ -73,9 +73,12 @@ resource "juju_integration" "haproxy_keepalived" {
 }
 
 resource "juju_integration" "maas_haproxy_http" {
-  count      = var.enable_haproxy ? 1 : 0
   model_uuid = juju_model.maas_model.uuid
-  for_each   = toset(["ingress-tcp", "ingress-tcp-temporal", "ingress-tcp-internal-http-api"])
+  for_each = toset(
+    var.enable_haproxy ?
+    ["ingress-tcp", "ingress-tcp-temporal", "ingress-tcp-internal-http-api"] :
+    []
+  )
 
   application {
     name     = juju_application.maas_region.name


### PR DESCRIPTION
requires https://github.com/canonical/maas-charms/pull/588 to land first

Adds the other non-tls relations when HAProxy is enabled

Resolves: #61