### PR TITLE
ci: fix juju_bootstrap due to LXD race

### DIFF
--- a/tests/terraform/modules/lxd-init/main.tf
+++ b/tests/terraform/modules/lxd-init/main.tf
@@ -41,6 +41,10 @@ resource "lxd_network" "net_test_dhcp" {
     "ipv4.nat"     = "true"
     "ipv6.address" = "none"
   }
+
+  # Ensure this network is created after net_test to avoid race conditions
+  # Related LXD bug: https://github.com/canonical/lxd/issues/18023
+  depends_on = [lxd_network.net_test]
 }
 
 # Create MAAS system project


### PR DESCRIPTION

## Summary

Bootstrap fails because Juju's network discovery queries all LXD bridge networks during controller initialization. When Terraform creates `net-test` and `net-test-dhcp` concurrently, they race to start dnsmasq processes, causing one network to enter a broken state (dnsmasq fails with "Address already in use"). Although the network appears in `lxc network list`, querying its state fails, which aborts the bootstrap.

**Fix:** Add `depends_on = [lxd_network.net_test]` to serialize network creation and prevent the race condition.

Related LXD bug: https://github.com/canonical/lxd/issues/18023