### PR TITLE
docs: add network forward instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To run the stacks and units in this repository, the following software must be i
 
 If you plan to deploy to a cloud that deploys machines on a private network (for example, OVN on MicroCloud), you must create a LXD container on the cloud first to use as a bastion. On the bastion, install the pre-requisites listed above, and run the relevant stacks or units from there.
 
-In this case, the MAAS API will only be accessible from within the private network, i.e. from the bastion and not on the uplink network. To solve this and make your MAAS API accessible on the uplink network, you need to setup a network forward. Please see [How to expose MAAS API externally on LXD](./docs/How-to%20guides/how_to_expose_maas_api_externally_on_lxd.md).
+In this case, the MAAS API will only be accessible from within the private network, i.e. from the bastion and not on the uplink network. To solve this and make your MAAS API accessible on the uplink network, you need to setup a network forward. Please see [How to expose MAAS API externally on LXD](./docs/How-to%20guides/how_to_expose_maas_api_externally_on_lxd.md) before deploying a unit or stack.
 
 ## How to use this repository
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ To run the stacks and units in this repository, the following software must be i
 - Terragrunt
 - A LXD cloud that is initialized and configured (see [How to configure LXD for Juju bootstrap](./docs/How-to%20guides/how_to_configure_lxd_for_juju_bootstrap.md))
 
-It is recommended to create a jumphost/bastion LXD container on the LXD cluster/server, install the pre-requisites, and run the relevant stacks or units from there.
+If you plan to deploy to a cloud that deploys machines on a private network (for example, OVN on MicroCloud), you must create a LXD container on the cloud first to use as a bastion. On the bastion, install the pre-requisites listed above, and run the relevant stacks or units from there.
+
+In this case, the MAAS API will only be accessible from within the private network, i.e. from the bastion and not on the uplink network. To solve this and make your MAAS API accessible on the uplink network, you need to setup a network forward. Please see [How to expose MAAS API externally on LXD](./docs/How-to%20guides/how_to_expose_maas_api_externally_on_lxd.md).
 
 ## How to use this repository
 

--- a/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
+++ b/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
@@ -1,6 +1,6 @@
 # How to expose MAAS API externally on LXD
 
-This document describes how to expose the MAAS API externally when deploying on a LXD cloud when using a private internal network, for example an [OVN network](https://documentation.ubuntu.com/lxd/default/reference/network_ovn/). This common for deployments on MicroCloud. 
+This document describes how to expose the MAAS API externally when deploying on a LXD cloud when using a private internal network, for example an [OVN network](https://documentation.ubuntu.com/lxd/default/reference/network_ovn/). This common for deployments on MicroCloud.
 
 If you are deploying on a LXD cloud with a private internal network, you will need to setup a network forward to access the MAAS API externally on the uplink network. This is because the MAAS API will only be accessible from within the private network by default, but you likely want to access the API from the uplink network as well. For cases where a virtual IP address is used to access MAAS, you will also need to reserve the VIP on your private network to ensure no other machines are assigned it. Follow this guide before running your `maas-deploy` unit if you want to ensure IP address reservation of a virtual IP address. 
 
@@ -8,7 +8,7 @@ If you are deploying on a LXD cloud with a private internal network, you will ne
 
 If you are specifying a `virtual_ip` for MAAS in the `maas-deploy` unit, you must ensure that the IP is reserved in your LXD cloud. 
 
-From LXD 5.21.5 onwards, you will be able to reserve an IP address using [`ivp4.dhcp.ranges`](https://documentation.ubuntu.com/lxd/default/reference/network_ovn/#network-ovn-network-conf:ipv4.dhcp.ranges). Until then, you will need to the following work around to reserve an IP address in OVN. In the following example, the private (OVN) network is `10.176.2.0/24`, and the uplink network is `10.239.7.0/24`:
+From LXD 5.21.5 onwards, you will be able to reserve an IP address using [`ipv4.dhcp.ranges`](https://documentation.ubuntu.com/lxd/default/reference/network_ovn/#network-ovn-network-conf:ipv4.dhcp.ranges). Until then, you will need to use the following work around to reserve an IP address in OVN. In the following example, the private (OVN) network is `10.176.2.0/24`, and the uplink network is `10.239.7.0/24`:
 
 On your LXD cloud, create a new container that acts as a VIP holder:
 ```bash
@@ -17,7 +17,7 @@ lxc init --empty vip-holder
 
 Create an interface on the container with your VIP address. This should be the same address as the `virtual_ip` you will specify in your `maas-deploy` configuration:
 ```bash
-lxc config device add vip-holder eth0 nic network=maas-labs-net name=eth0 ipv4.address=10.176.2.100
+lxc config device add vip-holder eth0 nic network=ovn-network-name name=eth0 ipv4.address=10.176.2.100
 ```
 
 ### Setup network forward
@@ -27,4 +27,4 @@ To forward the MAAS API accessible at `10.176.2.100` from the private network to
 lxc network forward create ovn-network-name 10.239.7.100 target_address=10.176.2.100
 ```
 
-You should now be able access the MAAS API from the specified IP on the uplink network. 
+You can now deploy your unit or stack, specifying your `virtual_ip` in the `maas-deploy` unit if required. 

--- a/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
+++ b/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
@@ -2,7 +2,7 @@
 
 This document describes how to expose the MAAS API externally when deploying on a LXD cloud when using a private internal network, for example an [OVN network](https://documentation.ubuntu.com/lxd/default/reference/network_ovn/). This common for deployments on MicroCloud. 
 
-If you are deploying on a LXD cloud with a private internal network, you will need to setup a network forward to access the MAAS API externally on the uplink network. This is because the MAAS API will only be accessible from within the private network by default, but you likely want to access the API from the uplink network as well. For cases where a virtual IP address is used to access MAAS, you will also need to reserve the VIP on your private network to ensure no other machines are assigned it. 
+If you are deploying on a LXD cloud with a private internal network, you will need to setup a network forward to access the MAAS API externally on the uplink network. This is because the MAAS API will only be accessible from within the private network by default, but you likely want to access the API from the uplink network as well. For cases where a virtual IP address is used to access MAAS, you will also need to reserve the VIP on your private network to ensure no other machines are assigned it. Follow this guide before running your `maas-deploy` unit if you want to ensure IP address reservation of a virtual IP address. 
 
 ### Reserve the VIP
 
@@ -27,4 +27,4 @@ To forward the MAAS API accessible at `10.176.2.100` from the private network to
 lxc network forward create ovn-network-name 10.239.7.100 target_address=10.176.2.100
 ```
 
-You should now be able to access the MAAS API from the uplink network. 
+You should now be able access the MAAS API from the specified IP on the uplink network. 

--- a/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
+++ b/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
@@ -1,0 +1,30 @@
+# How to expose MAAS API externally on LXD
+
+This document describes how to expose the MAAS API externally when deploying on a LXD cloud when using a private internal network, for example an [OVN network](https://documentation.ubuntu.com/lxd/default/reference/network_ovn/). This common for deployments on MicroCloud. 
+
+If you are deploying on a LXD cloud with a private internal network, you will need to setup a network forward to access the MAAS API externally on the uplink network. This is because the MAAS API will only be accessible from within the private network by default, but you likely want to access the API from the uplink network as well. For cases where a virtual IP address is used to access MAAS, you will also need to reserve the VIP on your private network to ensure no other machines are assigned it. 
+
+### Reserve the VIP
+
+If you are specifying a `virtual_ip` for MAAS in the `maas-deploy` unit, you must ensure that the IP is reserved in your LXD cloud. 
+
+From LXD 5.21.5 onwards, you will be able to reserve an IP address using [`ivp4.dhcp.ranges`](https://documentation.ubuntu.com/lxd/default/reference/network_ovn/#network-ovn-network-conf:ipv4.dhcp.ranges). Until then, you will need to the following work around to reserve an IP address in OVN. In the following example, the private (OVN) network is `10.176.2.0/24`, and the uplink network is `10.239.7.0/24`:
+
+On your LXD cloud, create a new container that acts as a VIP holder:
+```bash
+lxc init --empty vip-holder
+```
+
+Create an interface on the container with your VIP address. This should be the same address as the `virtual_ip` you will specify in your `maas-deploy` configuration:
+```bash
+lxc config device add vip-holder eth0 nic network=maas-labs-net name=eth0 ipv4.address=10.176.2.100
+```
+
+### Setup network forward
+
+To forward the MAAS API accessible at `10.176.2.100` from the private network to the uplink network, on your LXD cloud, run the following and specify the relevant uplink and private IP addresses and network name:
+```bash
+lxc network forward create ovn-network-name 10.239.7.100 target_address=10.176.2.100
+```
+
+You should now be able to access the MAAS API from the uplink network. 

--- a/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
+++ b/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
@@ -1,6 +1,6 @@
 # How to expose MAAS API externally on LXD
 
-This document describes how to expose the MAAS API externally when deploying on a LXD cloud when using a private internal network, for example an [OVN network](https://documentation.ubuntu.com/lxd/default/reference/network_ovn/). This common for deployments on MicroCloud.
+This document describes how to expose the MAAS API externally when deploying on a LXD cloud when using a private internal network, for example an [OVN network](https://documentation.ubuntu.com/lxd/default/reference/network_ovn/). This is the case for deployments on MicroCloud.
 
 If you are deploying on a LXD cloud with a private internal network, you will need to setup a network forward to access the MAAS API externally on the uplink network. This is because the MAAS API will only be accessible from within the private network by default, but you likely want to access the API from the uplink network as well. For cases where a virtual IP address is used to access MAAS, you will also need to reserve the VIP on your private network to ensure no other machines are assigned it. Follow this guide before running your `maas-deploy` unit if you want to ensure IP address reservation of a virtual IP address. 
 
@@ -24,7 +24,8 @@ lxc config device add vip-holder eth0 nic network=ovn-network-name name=eth0 ipv
 
 To forward the MAAS API accessible at `10.176.2.100` from the private network to the uplink network, on your LXD cloud, run the following and specify the relevant uplink and private IP addresses and network name:
 ```bash
-lxc network forward create ovn-network-name 10.239.7.100 target_address=10.176.2.100
+lxc network set UPLINK ipv4.routes=10.239.7.99/32
+lxc network forward create ovn-network-name 10.239.7.99 target_address=10.176.2.100
 ```
 
 You can now deploy your unit or stack, specifying your `virtual_ip` in the `maas-deploy` unit if required. 

--- a/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
+++ b/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
@@ -23,6 +23,7 @@ lxc config device add vip-holder eth0 nic network=ovn-network-name name=eth0 ipv
 ### Setup network forward
 
 To forward the MAAS API accessible at `10.176.2.100` from the private network to the uplink network, on your LXD cloud, run the following and specify the relevant uplink and private IP addresses and network name:
+
 ```bash
 lxc network forward create ovn-network-name 10.239.7.99 target_address=10.176.2.100
 ```
@@ -33,5 +34,7 @@ lxc network forward create ovn-network-name 10.239.7.99 target_address=10.176.2.
 > lxc network set UPLINK ipv4.routes=10.239.7.99/32
 > ```
 > Replace `UPLINK` with your actual uplink network name.
+
+For more details on network forwards on LXD, see [the docs](https://documentation.ubuntu.com/lxd/latest/howto/network_forwards/). 
 
 You can now deploy your unit or stack, specifying your `virtual_ip` in the `maas-deploy` unit if required. 

--- a/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
+++ b/docs/How-to guides/how_to_expose_maas_api_externally_on_lxd.md
@@ -24,8 +24,14 @@ lxc config device add vip-holder eth0 nic network=ovn-network-name name=eth0 ipv
 
 To forward the MAAS API accessible at `10.176.2.100` from the private network to the uplink network, on your LXD cloud, run the following and specify the relevant uplink and private IP addresses and network name:
 ```bash
-lxc network set UPLINK ipv4.routes=10.239.7.99/32
 lxc network forward create ovn-network-name 10.239.7.99 target_address=10.176.2.100
 ```
+
+> [!NOTE]
+> Before creating the network forward, your uplink address (10.239.7.99) must be configured as a route on the uplink network. An administrator of your LXD cloud must run:
+> ```bash
+> lxc network set UPLINK ipv4.routes=10.239.7.99/32
+> ```
+> Replace `UPLINK` with your actual uplink network name.
 
 You can now deploy your unit or stack, specifying your `virtual_ip` in the `maas-deploy` unit if required. 


### PR DESCRIPTION
Add documentation describing how to add network forwards to access the MAAS API on a private OVN network, i.e. for microcloud deployments. 

- Correct bastion information in prerequisites, making it an essential step for clouds using private internal networks
- Add document explaining the VIP reservation workaround and network forwarding. 