### PR TITLE
test: reduce test scope to a single deployment of a machine

### DIFF
--- a/tests/script.sh
+++ b/tests/script.sh
@@ -118,7 +118,7 @@ for STACK_DIR in "${STACK_DIRS[@]}"; do
     cd terraform-provider-maas
     make testacc TESTARGS='-skip="MAASBootSource_|MAASConfiguration|MAASVMHost_|MAASInstance_"'
     sleep 15
-    make testacc TESTARGS='-run="MAASVMHost_|MAASInstance_" -skip="TestAccDataSourceMAASVMHost_virsh"'
+    make testacc TESTARGS='-run="MAASInstance_basic"'
     make testacc TESTARGS='-run MAASConfiguration'
     cd $ROOT_DIR
 


### PR DESCRIPTION
There is no need to run the entire terraform provider test suite to test the deployment is working successfully. Testing both `VMHost` and `MAASInstance` tests deploys/commissions at worst 4 machines together. This increases flakiness and also increases the RAM resource requirements of the host. 

Reducing this to a single machine that is commissioned and deployed should improve both these aspects, but not solve the flakiness entirely


Note: I've attempted reducing the constraints on machine nodes, locally but it  2Gb is too little, so have chosen not to alter these in this PR. 