### PR TITLE
ci: explicitly specify token permissions to smoke GH action

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   run-smoke:
+    permissions:
+      contents: read
+      statuses: write
     runs-on: self-hosted-linux-amd64-noble-private-endpoint-small
     steps:
       # Validate commit SHA format


### PR DESCRIPTION
This is needed to allow setting statuses after a change in the org default permissions to read only