### PR TITLE
fix: aligned juju_bootstrap output with upstream module

### DIFF
--- a/docs/How-to guides/how_to_deploy_to_a_bootstrapped_controller.md
+++ b/docs/How-to guides/how_to_deploy_to_a_bootstrapped_controller.md
@@ -32,7 +32,7 @@ In this case, the Juju controller credentials must be provided by the user as en
      // Dependencies
     - juju_bootstrap_path = "../juju-bootstrap"
     + juju_cloud_name = "<cloud name>"
-    + juju_credentials = {
+    + juju_controller = {
     +   controller_addresses = [<controller address 1>, <controller address 2>, ...]
     +   username             = <username>
     +   password             = <password>

--- a/docs/How-to guides/how_to_login_to_juju_controller.md
+++ b/docs/How-to guides/how_to_login_to_juju_controller.md
@@ -15,7 +15,7 @@ Navigate to your unit or stack directory and run the appropriate command to extr
 Run this from the unit directory (for example, `units/maas-deploy`):
 
 ```bash
-CREDS=$(terragrunt output -json juju_credentials | jq -r '[.controller_addresses[0], .username, .password] | @tsv')
+CREDS=$(terragrunt output -json juju_controller | jq -r '[.controller_addresses[0], .username, .password] | @tsv')
 ```
 
 ### From a stack
@@ -23,7 +23,7 @@ CREDS=$(terragrunt output -json juju_credentials | jq -r '[.controller_addresses
 Run this from the stack directory (for example, `examples/stacks/single-node`):
 
 ```bash
-CREDS=$(terragrunt stack output juju_bootstrap.juju_credentials --json | jq -r '.juju_bootstrap.juju_credentials | [.controller_addresses[0], .username, .password] | @tsv')
+CREDS=$(terragrunt stack output juju_bootstrap.juju_controller --json | jq -r '.juju_bootstrap.juju_controller | [.controller_addresses[0], .username, .password] | @tsv')
 ```
 
 ## Log in to the controller

--- a/modules/juju-bootstrap/outputs.tf
+++ b/modules/juju-bootstrap/outputs.tf
@@ -2,7 +2,7 @@ output "juju_cloud" {
   value = juju_controller.controller.cloud.name
 }
 
-output "juju_credentials" {
+output "juju_controller" {
   value = {
     controller_addresses = juju_controller.controller.api_addresses
     username             = juju_controller.controller.username

--- a/modules/maas-deploy/main.tf
+++ b/modules/maas-deploy/main.tf
@@ -1,8 +1,8 @@
 provider "juju" {
-  controller_addresses = join(",", var.juju_credentials.controller_addresses)
-  username             = var.juju_credentials.username
-  password             = var.juju_credentials.password
-  ca_certificate       = var.juju_credentials.ca_certificate
+  controller_addresses = join(",", var.juju_controller.controller_addresses)
+  username             = var.juju_controller.username
+  password             = var.juju_controller.password
+  ca_certificate       = var.juju_controller.ca_certificate
 }
 
 resource "juju_model" "maas_model" {
@@ -121,9 +121,9 @@ resource "terraform_data" "juju_wait_for_all" {
     EOT
     environment = {
       MODEL                   = self.input.model
-      JUJU_CONTROLLER_ADDRESS = var.juju_credentials.controller_addresses[0]
-      JUJU_USERNAME           = var.juju_credentials.username
-      JUJU_PASSWORD           = var.juju_credentials.password
+      JUJU_CONTROLLER_ADDRESS = var.juju_controller.controller_addresses[0]
+      JUJU_USERNAME           = var.juju_controller.username
+      JUJU_PASSWORD           = var.juju_controller.password
     }
   }
 }
@@ -156,9 +156,9 @@ resource "terraform_data" "create_admin" {
       PASSWORD                = var.admin_password
       EMAIL                   = var.admin_email
       SSH_IMPORT              = var.admin_ssh_import
-      JUJU_CONTROLLER_ADDRESS = var.juju_credentials.controller_addresses[0]
-      JUJU_USERNAME           = var.juju_credentials.username
-      JUJU_PASSWORD           = var.juju_credentials.password
+      JUJU_CONTROLLER_ADDRESS = var.juju_controller.controller_addresses[0]
+      JUJU_USERNAME           = var.juju_controller.username
+      JUJU_PASSWORD           = var.juju_controller.password
     }
   }
 }
@@ -169,9 +169,9 @@ data "external" "maas_get_api_key" {
   query = {
     model                   = terraform_data.create_admin.output.model
     username                = var.admin_username
-    juju_controller_address = var.juju_credentials.controller_addresses[0]
-    juju_username           = var.juju_credentials.username
-    juju_password           = var.juju_credentials.password
+    juju_controller_address = var.juju_controller.controller_addresses[0]
+    juju_username           = var.juju_controller.username
+    juju_password           = var.juju_controller.password
   }
 }
 
@@ -180,8 +180,8 @@ data "external" "maas_get_api_url" {
 
   query = {
     model                   = terraform_data.create_admin.output.model
-    juju_controller_address = var.juju_credentials.controller_addresses[0]
-    juju_username           = var.juju_credentials.username
-    juju_password           = var.juju_credentials.password
+    juju_controller_address = var.juju_controller.controller_addresses[0]
+    juju_username           = var.juju_controller.username
+    juju_password           = var.juju_controller.password
   }
 }

--- a/modules/maas-deploy/variables.tf
+++ b/modules/maas-deploy/variables.tf
@@ -4,7 +4,7 @@ variable "ubuntu_version" {
   default     = "24.04"
 }
 
-variable "juju_credentials" {
+variable "juju_controller" {
   description = "The credentials to use when authenticating to the Juju controller."
   type = object({
     controller_addresses = list(string)

--- a/tests/script.sh
+++ b/tests/script.sh
@@ -85,7 +85,7 @@ for STACK_DIR in "${STACK_DIRS[@]}"; do
   if [ "$SMOKE_TEST" != "true" ]; then
 
     # Log in to Juju controller using credentials from Terragrunt stack output
-    JUJU_CREDS=$(terragrunt stack output -working-dir $STACK_DIR -json juju_bootstrap.juju_credentials | jq -r '.juju_bootstrap.juju_credentials')
+    JUJU_CREDS=$(terragrunt stack output -working-dir $STACK_DIR -json juju_bootstrap.juju_controller | jq -r '.juju_bootstrap.juju_controller')
     JUJU_CONTROLLER_ADDRESS=$(echo "$JUJU_CREDS" | jq -r '.controller_addresses[0]')
     JUJU_USERNAME=$(echo "$JUJU_CREDS" | jq -r '.username')
     JUJU_PASSWORD=$(echo "$JUJU_CREDS" | jq -r '.password')

--- a/units/maas-deploy/terragrunt.hcl
+++ b/units/maas-deploy/terragrunt.hcl
@@ -17,10 +17,9 @@ terraform {
 dependency "juju_bootstrap" {
   config_path = try(values.juju_bootstrap_path, null)
 
-
   mock_outputs = {
     juju_cloud = "mock-cloud-name"
-    juju_credentials = {
+    juju_controller = {
       controller_addresses = ["https://mock-controller:17070"]
       username             = "mock-username"
       password             = "mock-password"
@@ -109,7 +108,7 @@ inputs = merge(
   },
   {
     // --- Dependencies ---
-    juju_cloud_name  = coalesce(try(values.juju_cloud_name, null), try(dependency.juju_bootstrap.outputs.juju_cloud, null))
-    juju_credentials = coalesce(try(values.juju_credentials, null), try(dependency.juju_bootstrap.outputs.juju_credentials, null))
+    juju_cloud_name = coalesce(try(values.juju_cloud_name, null), try(dependency.juju_bootstrap.outputs.juju_cloud, null))
+    juju_controller = coalesce(try(values.juju_controller, null), try(dependency.juju_bootstrap.outputs.juju_controller, null))
   },
 )


### PR DESCRIPTION
The juju_bootstrap module is in the process of being hosted and maintained in the terraform-provider-juju repository.
As part of the PR work, the `juju_credentials` output is renamed to `juju_controller`, thus the dependency in the `maas_deploy` unit needs to be adapted.

See: https://github.com/juju/terraform-provider-juju/pull/1218#discussion_r3280933856