### PR TITLE
fix: set mock merge strategy to shallow in units

### DIFF
--- a/units/maas-config/terragrunt.hcl
+++ b/units/maas-config/terragrunt.hcl
@@ -17,6 +17,8 @@ terraform {
 dependency "maas_deploy" {
   config_path = try(values.maas_deploy_path, null)
 
+  mock_outputs_merge_strategy_with_state = "shallow"
+
   mock_outputs = {
     maas_api_url = "http://mock-maas"
     maas_api_key = "mock-password"

--- a/units/maas-deploy/terragrunt.hcl
+++ b/units/maas-deploy/terragrunt.hcl
@@ -17,6 +17,8 @@ terraform {
 dependency "juju_bootstrap" {
   config_path = try(values.juju_bootstrap_path, null)
 
+  mock_outputs_merge_strategy_with_state = "shallow"
+
   mock_outputs = {
     juju_cloud = "mock-cloud-name"
     juju_controller = {


### PR DESCRIPTION
Adding  `mock_outputs_merge_strategy_with_state = "shallow"` to dependency blocks in Terragrunt units allows mocks to be used when only partial outputs are available.