### PR TITLE
docs: update how to setup dhcp 

### DIFF
--- a/docs/How-to guides/how_to_setup_maas_dhcp.md
+++ b/docs/How-to guides/how_to_setup_maas_dhcp.md
@@ -143,7 +143,7 @@ Because this setup is specific to your infrastructure, DHCP configuration is not
    }
 
    terraform {
-     source = "${get_terragrunt_dir()}//"
+     source = "${get_terragrunt_dir()}"
    }
 
    dependency "maas_deploy" {

--- a/docs/How-to guides/how_to_setup_maas_dhcp.md
+++ b/docs/How-to guides/how_to_setup_maas_dhcp.md
@@ -58,7 +58,7 @@ __EOF
    netplan apply
    ```
    > [!NOTE]
-   > The above addresses assumes you may want to set a gateway as 10.20.0.1, which is outside of the scope of this document.
+> The above addresses assume you may want to set a gateway as 10.20.0.1, which is outside of the scope of this document.
 5. After a few moments, you should be able to see the relevant subnet discovered in MAAS, if network discovery is enabled. You can now use this network to enable DHCP using Terragrunt.
 
 ## Enable DHCP on the discovered subnet with Terragrunt

--- a/docs/How-to guides/how_to_setup_maas_dhcp.md
+++ b/docs/How-to guides/how_to_setup_maas_dhcp.md
@@ -1,6 +1,6 @@
 # How to setup MAAS DHCP
 
-You likely want to have a subnet available in MAAS that has DHCP enabled, perhaps to use as a PXE subnet. To enable MAAS-provided DHCP on a rack controller requires having a subnet available that will be used for DHCP, and an additional interface on the relevant rack controllers connected to this subnet. This guide details the manual steps required to achieve this, as there is no current way to manage this with Terraform.
+You likely want to have a subnet available in MAAS that has DHCP enabled, perhaps to use as a PXE subnet. To enable MAAS-provided DHCP on a rack controller requires having a subnet available that will be used for DHCP, and an additional interface on the relevant rack controller connected to this subnet. This guide details the steps required to achieve this.
 
 ## Prerequisites
 
@@ -32,7 +32,7 @@ locations:
 __EOF
 ```
 ## Attach the network to the rack controller
-1. Identify the rack controller you would like MAAS to provide DHCP from. If `enable_rack_mode=True`, this will be a machine listed in the `terraform output maas_machines` of the `maas-deploy` module.
+1. Identify the rack controller you would like MAAS to provide DHCP from. If `enable_rack_mode=True`, this will be a machine listed in the `terragrunt stack output maas_deploy.maas_machines` of the `maas-deploy` module.
 2. Attach the desired network (`maas-pxe`) to the desired rack controller (`$NAME`, for example `juju-2c9858-1`) as a new interface (`eth1`):
    ```
    lxc network attach maas-pxe $NAME eth1
@@ -59,16 +59,56 @@ __EOF
    ```
    > [!NOTE]
    > The above addresses assumes you may want to set a gateway as 10.20.0.1, which is outside of the scope of this document.
-5. After a few moments, you should be able to see the relevant subnet discovered in MAAS, if network discovery is enabled. You can now use this network to enable DHCP using terraform.
+5. After a few moments, you should be able to see the relevant subnet discovered in MAAS, if network discovery is enabled. You can now use this network to enable DHCP using Terragrunt.
 
-## Enable DHCP on the discovered subnet with Terraform
-You can now enable DHCP with Terraform:
+## Enable DHCP on the discovered subnet with Terragrunt
 
-1. Add the following to
+Because this setup is specific to your infrastructure, DHCP configuration is not part of the shared modules. Instead, create a small local module in your deployment repo and add it as a unit in your existing stack.
 
-   `/modules/maas-config/main.tf`
+1. In your deployment repo, create the following files:
+
+   `modules/maas-dhcp/variables.tf`
    ```hcl
-   # Enable DHCP
+   variable "maas_url" {
+     description = "The MAAS URL in the format of: http://127.0.0.1:5240/MAAS"
+     type        = string
+   }
+
+   variable "maas_key" {
+     description = "The MAAS API key"
+     type        = string
+   }
+
+   variable "rack_controller" {
+     description = "The hostname of the MAAS rack controller to enable DHCP on"
+     type        = string
+   }
+
+   variable "pxe_subnet" {
+     description = "The subnet CIDR to serve DHCP from the MAAS rack controller"
+     type        = string
+   }
+   ```
+
+   `modules/maas-dhcp/versions.tf`
+   ```hcl
+   terraform {
+     required_providers {
+       maas = {
+         source  = "canonical/maas"
+         version = "~> 2.6"
+       }
+     }
+   }
+   ```
+
+   `modules/maas-dhcp/main.tf`
+   ```hcl
+   provider "maas" {
+     api_key = var.maas_key
+     api_url = var.maas_url
+   }
+
    data "maas_rack_controller" "dhcp_rack" {
      hostname = var.rack_controller
    }
@@ -78,40 +118,70 @@ You can now enable DHCP with Terraform:
    }
 
    data "maas_fabric" "pxe_fabric" {
-     name = data.maas_subnet.pxe[0].fabric
+     name = data.maas_subnet.pxe.fabric
    }
 
    resource "maas_subnet_ip_range" "dhcp_range" {
-     subnet   = data.maas_subnet.pxe[0].id
+     subnet   = data.maas_subnet.pxe.id
      type     = "dynamic"
-     start_ip = cidrhost(data.maas_subnet.pxe[0].cidr, 99)
-     end_ip   = cidrhost(data.maas_subnet.pxe[0].cidr, 254)
+     start_ip = cidrhost(data.maas_subnet.pxe.cidr, 99)
+     end_ip   = cidrhost(data.maas_subnet.pxe.cidr, 254)
    }
 
    resource "maas_vlan_dhcp" "dhcp_enabled" {
-     fabric                  = data.maas_fabric.pxe_fabric[0].id
-     vlan                    = data.maas_subnet.pxe[0].vid
-     primary_rack_controller = data.maas_rack_controller.dhcp_rack[0].id
-     ip_ranges               = [maas_subnet_ip_range.dhcp_range[0].id]
+     fabric                  = data.maas_fabric.pxe_fabric.id
+     vlan                    = data.maas_subnet.pxe.vid
+     primary_rack_controller = data.maas_rack_controller.dhcp_rack.id
+     ip_ranges               = [maas_subnet_ip_range.dhcp_range.id]
    }
    ```
-   `modules/maas-config/variables.tf`
+
+   `modules/maas-dhcp/terragrunt.hcl`
    ```hcl
-   variable "rack_controller" {
-     description = "The hostname of the MAAS rack controller to enable DHCP on"
-     type        = string
+   include "root" {
+     path = find_in_parent_folders("root.hcl")
    }
 
-   variable "pxe_subnet" {
-     description = "The subnet to serve DHCP from the MAAS rack controller"
-     type        = string
+   terraform {
+     source = "${get_terragrunt_dir()}//"
+   }
+
+   dependency "maas_deploy" {
+     config_path = values.maas_deploy_path
+
+     mock_outputs_merge_strategy_with_state = "shallow"
+
+     mock_outputs = {
+       maas_api_url = "http://mock-maas"
+       maas_api_key = "mock-password"
+     }
+   }
+
+   inputs = {
+     maas_url        = dependency.maas_deploy.outputs.maas_api_url
+     maas_key        = dependency.maas_deploy.outputs.maas_api_key
+     rack_controller = values.rack_controller
+     pxe_subnet      = values.pxe_subnet
    }
    ```
-   `config/maas-config/config.tfvars`, filling out the appropriate values
+
+2. Add the following unit to your `terragrunt.stack.hcl`, after the `maas_config` unit. Replace `<$NAME>` with the rack controller hostname (e.g. `juju-2c9858-1`) and adjust the subnet if needed:
+
    ```hcl
-   # The hostname of the MAAS rack controller to enable DHCP
-   rack_controller = <$NAME of rack controller>
-   # The subnet to serve DHCP from the MAAS rack controller
-   pxe_subnet = "10.20.0.0/24"
+   unit "maas_dhcp" {
+     source = "./modules/maas-dhcp"
+     path   = "maas-dhcp"
+
+     values = {
+       maas_deploy_path = "../maas-deploy"
+       rack_controller  = "<$NAME>"
+       pxe_subnet       = "10.20.0.0/24"
+     }
+   }
    ```
-1. Apply your new `maas-config` plan. You're done, DHCP should now be enabled on the specified rack.
+
+3. Apply the stack:
+   ```bash
+   terragrunt stack run apply
+   ```
+   DHCP should now be enabled on the specified rack.

--- a/docs/How-to guides/how_to_setup_maas_dhcp.md
+++ b/docs/How-to guides/how_to_setup_maas_dhcp.md
@@ -65,7 +65,7 @@ __EOF
 
 Because this setup is specific to your infrastructure, DHCP configuration is not part of the shared modules. Instead, create a small local module in your deployment repo and add it as a unit in your existing stack.
 
-1. In your deployment repo, create the following files:
+1. In your deployment repo, create the following files and copy the contents into them below:
 
    `modules/maas-dhcp/variables.tf`
    ```hcl
@@ -165,7 +165,7 @@ Because this setup is specific to your infrastructure, DHCP configuration is not
    }
    ```
 
-2. Add the following unit to your `terragrunt.stack.hcl`, after the `maas_config` unit. Replace `<$NAME>` with the rack controller hostname (e.g. `juju-2c9858-1`) and adjust the subnet if needed:
+2. Add the following unit to your `terragrunt.stack.hcl`, after the `maas_config` unit. Update the `source` path to point to your local `maas-dhcp` module you've just created, `<$NAME>` with the rack controller hostname (e.g. `juju-2c9858-1`) and adjust the subnet if needed:
 
    ```hcl
    unit "maas_dhcp" {


### PR DESCRIPTION
The old document was when the repository was just a collection of modules. This revised how-to instructs a user to create their own local unit. 

Note that this is still not a supported unit we provide because we are still waiting on some Juju features relating to static ips in order to make this instruction work for all LXD clouds (see https://github.com/canonical/maas-terraform-modules/issues/32). 

AI was used to assist in the update of these docs. 

Resolves: https://github.com/canonical/maas-terraform-modules/issues/31