### PR TITLE
fix: add missing environment variables to local exec

### DIFF
--- a/modules/maas-deploy/backup.tf
+++ b/modules/maas-deploy/backup.tf
@@ -84,6 +84,11 @@ resource "juju_application" "s3_integrator" {
       rm -rf $JUJU_DATA
     EOT
     )
+    environment = {
+      JUJU_CONTROLLER_ADDRESS = var.juju_controller.controller_addresses[0]
+      JUJU_USERNAME           = var.juju_controller.username
+      JUJU_PASSWORD           = var.juju_controller.password
+    }
   }
 }
 


### PR DESCRIPTION
These missing environment variables prevented running sync-s3-credentials on the s3-integrator charm, which was failing silently. 

Resolves: #105 