### PR TITLE
chore: use 3.7/candidate version of maas-region charm

### DIFF
--- a/examples/stacks/multi-node/terragrunt.stack.hcl
+++ b/examples/stacks/multi-node/terragrunt.stack.hcl
@@ -158,7 +158,7 @@ unit "maas_deploy" {
 
     // -- Workload: MAAS
     // Operator channel for MAAS Region Controller deployment
-    charm_maas_region_channel = "latest/edge"
+    charm_maas_region_channel = "3.7/candidate"
     // Operator channel revision for MAAS Region Controller deployment
     // charm_maas_region_revision = ...
     // Operator configuration for MAAS Region Controller deployment

--- a/examples/stacks/single-node/terragrunt.stack.hcl
+++ b/examples/stacks/single-node/terragrunt.stack.hcl
@@ -135,7 +135,7 @@ unit "maas_deploy" {
 
     // -- Workload: MAAS
     // Operator channel for MAAS Region Controller deployment
-    charm_maas_region_channel = "latest/edge"
+    charm_maas_region_channel = "3.7/candidate"
     // Operator channel revision for MAAS Region Controller deployment
     // charm_maas_region_revision = ...
     // Operator configuration for MAAS Region Controller deployment

--- a/examples/units/maas-deploy/terragrunt.hcl
+++ b/examples/units/maas-deploy/terragrunt.hcl
@@ -110,7 +110,7 @@ inputs = {
 
   # Description: Operator channel for MAAS Region Controller deployment
   # Type: string
-  # charm_maas_region_channel = "latest/edge"
+  # charm_maas_region_channel = "3.7/candidate"
 
   # Description: Operator channel revision for MAAS Region Controller deployment
   # Type: number

--- a/modules/maas-deploy/variables.tf
+++ b/modules/maas-deploy/variables.tf
@@ -149,7 +149,7 @@ variable "charm_postgresql_config" {
 variable "charm_maas_region_channel" {
   description = "Operator channel for MAAS Region Controller deployment"
   type        = string
-  default     = "latest/edge"
+  default     = "3.7/candidate"
 }
 
 variable "charm_maas_region_revision" {


### PR DESCRIPTION
After pointing the maas-region latest/edge to the cutting edge of the not-yet-released MAAS 3.8 snap, it became more fragile by its nature. This instructs maas-terraform-modules to default to the far more stable 3.7/candidate charm until a 3.7/stable is available, switching the default across the module variable and the single-node, multi-node, and unit examples.