### PR TITLE
chore: use valid 3-part format for mock maas_api_key

### DIFF
--- a/units/maas-config/terragrunt.hcl
+++ b/units/maas-config/terragrunt.hcl
@@ -21,7 +21,7 @@ dependency "maas_deploy" {
 
   mock_outputs = {
     maas_api_url = "http://mock-maas"
-    maas_api_key = "mock-password"
+    maas_api_key = "mock:mock:mock"
   }
 }
 


### PR DESCRIPTION
Change the `maas_api_key` mock output in `units/maas-config/terragrunt.hcl` from `mock-password` to a syntactically valid 3-part value `mock:mock:mock`.