### PR TITLE
feat(maas-deploy): add configurable arch for machines and charm bases

### DIFF
--- a/modules/maas-deploy/api.tf
+++ b/modules/maas-deploy/api.tf
@@ -20,7 +20,7 @@ resource "juju_machine" "haproxy_machines" {
   model_uuid  = juju_model.maas_model.uuid
   base        = "ubuntu@${var.haproxy_ubuntu_version}"
   name        = "haproxy-${count.index}"
-  constraints = var.haproxy_constraints
+  constraints = "arch=${var.arch} ${var.haproxy_constraints}"
   placement   = length(var.zone_list) > 0 ? "zone=${element(var.zone_list, count.index)}" : null
 }
 
@@ -29,6 +29,8 @@ resource "juju_application" "haproxy" {
   name       = "haproxy"
   model_uuid = juju_model.maas_model.uuid
   machines   = [for m in juju_machine.haproxy_machines : m.machine_id]
+
+  constraints = "arch=${var.arch}"
 
   charm {
     name     = "haproxy"

--- a/modules/maas-deploy/backup.tf
+++ b/modules/maas-deploy/backup.tf
@@ -4,7 +4,7 @@ resource "juju_machine" "backup" {
   model_uuid  = juju_model.maas_model.uuid
   base        = startswith(var.charm_s3_integrator_channel, "2/") ? "ubuntu@24.04" : "ubuntu@22.04"
   name        = "backup"
-  constraints = var.s3_constraints
+  constraints = "arch=${var.arch} ${var.s3_constraints}"
 }
 
 resource "juju_secret" "s3_credentials" {
@@ -42,6 +42,8 @@ resource "juju_application" "s3_integrator" {
   name       = "s3-integrator-${each.value}"
   model_uuid = juju_model.maas_model.uuid
   machines   = [for m in juju_machine.backup : m.machine_id]
+
+  constraints = "arch=${var.arch}"
 
   charm {
     name     = "s3-integrator"

--- a/modules/maas-deploy/main.tf
+++ b/modules/maas-deploy/main.tf
@@ -32,7 +32,7 @@ resource "juju_machine" "postgres_machines" {
   model_uuid  = juju_model.maas_model.uuid
   base        = "ubuntu@${var.postgres_ubuntu_version}"
   name        = "postgres-${count.index}"
-  constraints = var.postgres_constraints
+  constraints = "arch=${var.arch} ${var.postgres_constraints}"
   placement   = length(var.zone_list) > 0 ? "zone=${element(var.zone_list, count.index)}" : null
 }
 
@@ -41,7 +41,7 @@ resource "juju_machine" "maas_machines" {
   model_uuid        = juju_model.maas_model.uuid
   base              = "ubuntu@${var.maas_ubuntu_version}"
   name              = "maas-${count.index}"
-  constraints       = var.maas_constraints
+  constraints       = "arch=${var.arch} ${var.maas_constraints}"
   placement         = length(var.zone_list) > 0 ? "zone=${element(var.zone_list, count.index)}" : null
   wait_for_hostname = true
 }
@@ -50,6 +50,8 @@ resource "juju_application" "postgresql" {
   name       = "postgresql"
   model_uuid = juju_model.maas_model.uuid
   machines   = [for m in juju_machine.postgres_machines : m.machine_id]
+
+  constraints = "arch=${var.arch}"
 
   charm {
     name     = "postgresql"
@@ -65,6 +67,8 @@ resource "juju_application" "maas_region" {
   name       = "maas-region"
   model_uuid = juju_model.maas_model.uuid
   machines   = [for m in juju_machine.maas_machines : m.machine_id]
+
+  constraints = "arch=${var.arch}"
 
   charm {
     name     = "maas-region"

--- a/modules/maas-deploy/variables.tf
+++ b/modules/maas-deploy/variables.tf
@@ -37,6 +37,12 @@ variable "juju_cloud_region" {
   default     = "default"
 }
 
+variable "arch" {
+  description = "CPU architecture for machines and charm bases (e.g. amd64, arm64)."
+  type        = string
+  default     = "amd64"
+}
+
 variable "maas_constraints" {
   description = <<EOF
     Use the following constraints for the machines


### PR DESCRIPTION
Fixes #111

## Problem
The `juju_application` resources in `modules/maas-deploy` set no `constraints`, so the `juju/juju` provider defaults the requested base architecture to the client's arch (amd64). Applying from an amd64 client against arm64 machines fails:

```
base from placements "arm64/ubuntu/24.04/stable", does not match requested base "amd64/ubuntu/24.04/stable"
```

The `juju_machine` resources also lacked an explicit `arch` constraint.

## Change
- Add an `arch` variable (default `amd64`).
- Apply `constraints = "arch=${var.arch}"` to the `postgresql`, `maas_region`, `haproxy` and `s3_integrator` applications (those bound to machines).
- Merge `arch=${var.arch}` into the `postgres`, `maas`, `haproxy` and `backup` machine constraint strings.

Validated with `terraform fmt` and `terraform validate` (configuration is valid). Changes are surgical; no unrelated refactoring.