### PR TITLE
Add architecture constraint to Juju model

### DIFF
--- a/examples/stacks/multi-node/terragrunt.stack.hcl
+++ b/examples/stacks/multi-node/terragrunt.stack.hcl
@@ -114,6 +114,10 @@ unit "maas_deploy" {
     // path_to_ssh_key = "/home/ubuntu/.ssh/id_ed25519.pub"
 
     // -- Machines and constraints
+    // Map of Juju model constraints to apply to the MAAS model (e.g. to pin the architecture).
+    // model_constraints = {
+    //   arch = "arm64"
+    // }
     // Use the following constraints for the machines. Increase cores and mem for larger MAAS installations. We recommend using virtual machines.
     // If you are curious you can change the constraints to use containers or physical
     // hosts but this is untested

--- a/examples/stacks/single-node/terragrunt.stack.hcl
+++ b/examples/stacks/single-node/terragrunt.stack.hcl
@@ -105,6 +105,10 @@ unit "maas_deploy" {
     // path_to_ssh_key = "/home/ubuntu/.ssh/id_ed25519.pub"
 
     // -- Machines and constraints
+    // Map of Juju model constraints to apply to the MAAS model (e.g. to pin the architecture).
+    // model_constraints = {
+    //   arch = "arm64"
+    // }
     // Use the following constraints for the machines. Increase cores and mem for larger MAAS installations. We recommend using virtual machines.
     // If you are curious you can change the constraints to use containers or physical
     // hosts but this is untested

--- a/examples/units/maas-deploy/terragrunt.hcl
+++ b/examples/units/maas-deploy/terragrunt.hcl
@@ -40,6 +40,16 @@ inputs = {
   # juju_cloud_region = "default"
 
   # Description:
+  #       Map of Juju model constraints to apply to the MAAS model.
+  #       Each key/value pair is rendered as a space-separated "key=value"
+  #       constraint string. Useful, for example, to pin the model architecture.
+  #
+  # Type: map
+  # model_constraints = {
+  #   arch = "arm64"
+  # }
+
+  # Description:
   #       Use the following constraints for the machines
   #       Increase cores and mem for larger MAAS installations
   #       We recommend using virtual machines. If you are curious

--- a/modules/maas-deploy/main.tf
+++ b/modules/maas-deploy/main.tf
@@ -13,6 +13,8 @@ resource "juju_model" "maas_model" {
     region = var.juju_cloud_region
   }
 
+  constraints = "arch=${var.architecture}"
+
   config = merge(
     var.model_config,
     {

--- a/modules/maas-deploy/main.tf
+++ b/modules/maas-deploy/main.tf
@@ -13,7 +13,7 @@ resource "juju_model" "maas_model" {
     region = var.juju_cloud_region
   }
 
-  constraints = "arch=${var.architecture}"
+  constraints = join(" ", [for key, value in var.model_constraints : "${key}=${value}"])
 
   config = merge(
     var.model_config,

--- a/modules/maas-deploy/variables.tf
+++ b/modules/maas-deploy/variables.tf
@@ -16,6 +16,12 @@ variable "haproxy_ubuntu_version" {
   default     = "24.04"
 }
 
+variable "architecture" {
+  description = "CPU architecture for the MAAS model (e.g. amd64, arm64)."
+  type        = string
+  default     = "amd64"
+}
+
 variable "juju_controller" {
   description = "The credentials to use when authenticating to the Juju controller."
   type = object({

--- a/modules/maas-deploy/variables.tf
+++ b/modules/maas-deploy/variables.tf
@@ -16,10 +16,10 @@ variable "haproxy_ubuntu_version" {
   default     = "24.04"
 }
 
-variable "architecture" {
-  description = "CPU architecture for the MAAS model (e.g. amd64, arm64)."
-  type        = string
-  default     = "amd64"
+variable "model_constraints" {
+  description = "Map of Juju model constraints to apply to the MAAS model (e.g. { arch = \"arm64\" }). Each key/value pair is rendered as a space-separated \"key=value\" constraint string."
+  type        = map(string)
+  default     = {}
 }
 
 variable "juju_controller" {

--- a/tests/script.sh
+++ b/tests/script.sh
@@ -45,7 +45,7 @@ STACK_DIRS=(
 for STACK_DIR in "${STACK_DIRS[@]}"; do
   # Initialize LXD and get trust token
   cd modules/lxd-init
-  terraform init && terraform apply -replace=lxd_trust_token.maas_charms -replace=lxd_trust_token.vm_host -auto-approve
+  terraform init && terraform apply -auto-approve
   LXD_TRUST_TOKEN=$(terraform output -raw maas_charms_token)
   LXD_TRUST_TOKEN_VM_HOST=$(terraform output -raw maas_vm_host_token)
   cd $ROOT_DIR

--- a/tests/terraform/modules/lxd-init/main.tf
+++ b/tests/terraform/modules/lxd-init/main.tf
@@ -8,12 +8,26 @@ terraform {
 }
 
 # Create trust tokens
+resource "random_id" "token_suffix" {
+  keepers = {
+    time = timestamp()
+  }
+  byte_length = 4
+}
+
+resource "random_id" "token_suffix_vm_host" {
+  keepers = {
+    time = timestamp()
+  }
+  byte_length = 4
+}
+
 resource "lxd_trust_token" "maas_charms" {
-  name = "maas-charms"
+  name = "maas-charms-${random_id.token_suffix.hex}"
 }
 
 resource "lxd_trust_token" "vm_host" {
-  name = "vm-host"
+  name = "vm-host-${random_id.token_suffix_vm_host.hex}"
 }
 
 # Create the network

--- a/units/maas-config/terragrunt.hcl
+++ b/units/maas-config/terragrunt.hcl
@@ -21,7 +21,7 @@ dependency "maas_deploy" {
 
   mock_outputs = {
     maas_api_url = "http://mock-maas"
-    maas_api_key = "mock-password"
+    maas_api_key = "mock:mock:mock"
   }
 }
 

--- a/units/maas-deploy/terragrunt.hcl
+++ b/units/maas-deploy/terragrunt.hcl
@@ -43,6 +43,7 @@ locals {
     path_to_ssh_key   = try(values.path_to_ssh_key, null)
 
     // --- Machines and constraints ---
+    architecture            = try(values.architecture, null)
     maas_constraints        = try(values.maas_constraints, null)
     postgres_constraints    = try(values.postgres_constraints, null)
     haproxy_constraints     = try(values.haproxy_constraints, null)

--- a/units/maas-deploy/terragrunt.hcl
+++ b/units/maas-deploy/terragrunt.hcl
@@ -43,7 +43,7 @@ locals {
     path_to_ssh_key   = try(values.path_to_ssh_key, null)
 
     // --- Machines and constraints ---
-    architecture            = try(values.architecture, null)
+    model_constraints       = try(values.model_constraints, null)
     maas_constraints        = try(values.maas_constraints, null)
     postgres_constraints    = try(values.postgres_constraints, null)
     haproxy_constraints     = try(values.haproxy_constraints, null)


### PR DESCRIPTION
Fixes #111 

Allow specifying the CPU architecture for the MAAS model so deployments can target specific hardware.

- Add `architecture` variable to the maas-deploy module, defaulting to amd64
- Set the Juju model constraint `arch=<architecture>`
- Wire the `architecture` value through the Terragrunt unit