### PR TITLE
ci: fix the LXD token recreation

### DIFF
--- a/tests/script.sh
+++ b/tests/script.sh
@@ -45,7 +45,7 @@ STACK_DIRS=(
 for STACK_DIR in "${STACK_DIRS[@]}"; do
   # Initialize LXD and get trust token
   cd modules/lxd-init
-  terraform init && terraform apply -replace=lxd_trust_token.maas_charms -replace=lxd_trust_token.vm_host -auto-approve
+  terraform init && terraform apply -auto-approve
   LXD_TRUST_TOKEN=$(terraform output -raw maas_charms_token)
   LXD_TRUST_TOKEN_VM_HOST=$(terraform output -raw maas_vm_host_token)
   cd $ROOT_DIR

--- a/tests/terraform/modules/lxd-init/main.tf
+++ b/tests/terraform/modules/lxd-init/main.tf
@@ -8,12 +8,26 @@ terraform {
 }
 
 # Create trust tokens
+resource "random_id" "token_suffix" {
+  keepers = {
+    time = timestamp()
+  }
+  byte_length = 4
+}
+
+resource "random_id" "token_suffix_vm_host" {
+  keepers = {
+    time = timestamp()
+  }
+  byte_length = 4
+}
+
 resource "lxd_trust_token" "maas_charms" {
-  name = "maas-charms"
+  name = "maas-charms-${random_id.token_suffix.hex}"
 }
 
 resource "lxd_trust_token" "vm_host" {
-  name = "vm-host"
+  name = "vm-host-${random_id.token_suffix_vm_host.hex}"
 }
 
 # Create the network


### PR DESCRIPTION
When requesting a trust token from an LXD server, an optional name parameter can be provided. This specifies the client/identity name created on the server when a client redeems the token.

Prior to LXD 5.21.5, duplicate identity names were allowed because clients were distinguished by certificate fingerprint. Starting in 5.21.5 (via canonical/lxd#16205), LXD strictly enforces identity name uniqueness.

To resolve CI failures caused by this change, this PR appends a random suffix to the trust token identity names. On each terraform apply, a unique identity name is generated so Juju can authenticate with LXD and register the cloud without identity collisions.